### PR TITLE
fix server header and add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,78 @@
-# OFEM
-OnlyFans Express Manager
--Readmefile.me need to be written
+<!-- Modified 2025-08-05 – v1.0 -->
+
+# OnlyFans Express Messenger (OFEM)
+
+OFEM is a small dashboard that helps an OnlyFans creator greet fans by name and send a
+personalised message to everyone in one pass.  It uses the official OnlyFans API to
+fetch the fan list and send direct messages and OpenAI GPT‑4 to generate friendly
+nicknames.
+
+## Features
+
+- **Update Fan Names** – Fetches all fans and assigns each a short “Parker name” using
+  GPT‑4 according to the rules in the project plan.  Names can be edited and saved.
+- **Send Personalised DM** – Sends a message to every fan, greeting each with their
+  Parker name.  Shows a green dot for success and red for failure.  Sending can be
+  aborted and auto‑stops after ten consecutive errors.
+
+## Prerequisites
+
+- Node.js 14+
+- PostgreSQL database accessible via `DATABASE_URL`
+- OnlyFans API key
+- OpenAI API key
+
+## Setup
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment**
+
+   Copy `.env.example` to `.env` and edit the values for your database, OnlyFans API
+   key and OpenAI key.
+
+3. **Start PostgreSQL (Docker)**
+
+   A `docker-compose.yml` is provided to launch a local database quickly:
+
+   ```bash
+   docker compose up -d db
+   ```
+
+   The default connection string is
+   `postgres://postgres:postgres@localhost:5432/ofdb`.
+
+4. **Start the server**
+
+   ```bash
+   npm start
+   ```
+
+   The server listens on <http://localhost:3000> by default.  A convenience script
+   `start.command` (macOS) runs `npm install` if needed and then launches the server.
+
+## Usage
+
+1. Open a browser to <http://localhost:3000>.
+2. Click **Update Fan Names** to load fans and generate Parker names.
+3. Edit any names and click **Save** beside a fan to persist the change.
+4. Type the message to broadcast.  Use `{name}` or `[name]` as a placeholder or leave
+   it out to have the greeting prefixed automatically.
+5. Click **Send Personalised DM to All Fans** to start sending.  Use **Abort Sending**
+   to stop early.
+
+## Notes
+
+- All OnlyFans and OpenAI requests happen server‑side; API keys are never exposed in the
+  browser.
+- Message sending is rate‑limited (500 ms delay between fans) to reduce the chance of
+  hitting OnlyFans rate limits.
+- The project currently supports only the two features described above but is structured
+  to allow further expansion.
+
+<!-- End of File – Last modified 2025-08-05 -->
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+## OnlyFans Express Messenger
+## File: docker-compose.yml
+## Purpose: Local Postgres for development
+## Created: 2025-08-05 – v1.0
+
+version: '3.8'
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ofdb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+## End of File – Last modified 2025-08-05

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
-// server.js content will be filled in next step/* OnlyFans Express Messenger (OFEM)
-File: server.js
-Purpose: Express server for OFEM (OnlyFans integration and ChatGPT usage)
-Created: 2025-08-02 – v1.0
+/*  OnlyFans Express Messenger (OFEM)
+    File: server.js
+    Purpose: Express server for OFEM (OnlyFans integration and ChatGPT usage)
+    Created: 2025-08-02 – v1.0
 */
 
 const express = require('express');


### PR DESCRIPTION
## Summary
- repair `server.js` header comment so the server starts correctly
- provide full project setup and usage instructions in a new README
- add a Docker-based PostgreSQL database for local development

## Testing
- `npm test` *(fails: Missing script "test")*
- `docker compose up -d db` *(fails: command not found: docker)*
- `node server.js` *(fails: connect ECONNREFUSED ::1:5432)*


------
https://chatgpt.com/codex/tasks/task_e_688e62ecaac0832182d8694c5ee91b61