### PR TITLE
feat: add database setup scripts and env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,18 @@
+# OnlyFans Express Messenger - Example Environment Variables
 # Rename this file to .env and fill in the values
-# PostgreSQL connection string
-DATABASE_URL=postgres://username:password@localhost:5432/ofem
 
-# OnlyFans API key
+# OnlyFans API Key (for OnlyFans API access)
 ONLYFANS_API_KEY=your_onlyfans_api_key_here
 
-# OpenAI API key
+# OpenAI API Key (for GPT-4 integration, if used)
 OPENAI_API_KEY=your_openai_api_key_here
 
-# Optional: change the port if needed
-# PORT=3000
+# PostgreSQL Database settings
+DB_NAME=ofem                      # Name of the PostgreSQL database for OFEM
+DB_USER=postgres                  # Database username (default PostgreSQL user is "postgres")
+DB_PASSWORD=your_postgres_password_here   # Password for the above user
+DB_HOST=localhost                 # Host address (localhost for local database)
+DB_PORT=5432                      # Port number (5432 is default for PostgreSQL)
+
+# Express server port
+PORT=3000                         # Port for the Express server (defaults to 3000)

--- a/README.md
+++ b/README.md
@@ -18,35 +18,32 @@ nicknames.
 ## Prerequisites
 
 - Node.js 14+
-- PostgreSQL database accessible via `DATABASE_URL`
+- PostgreSQL (credentials provided in `.env`)
 - OnlyFans API key
 - OpenAI API key
 
 ## Setup
 
-1. **Install dependencies**
-
-   ```bash
-   npm install
-   ```
-
-2. **Configure environment**
+1. **Configure environment**
 
    Copy `.env.example` to `.env` and edit the values for your database, OnlyFans API
    key and OpenAI key.
 
-3. **Create database**
-
-   Create the database referenced by `DATABASE_URL` and ensure PostgreSQL is running.
-
-4. **Start the server**
+2. **Install dependencies and set up the database**
 
    ```bash
-   npm start
+   ./install.command
    ```
 
-   The server listens on <http://localhost:3000> by default.  A convenience script
-   `start.command` (macOS) runs `npm install` if needed and then launches the server.
+   This script runs `npm install` and executes the migration to create the `fans` table.
+
+3. **Start the server**
+
+   ```bash
+   ./start.command
+   ```
+
+   The server listens on <http://localhost:3000> by default.
 
 ## Usage
 

--- a/install.command
+++ b/install.command
@@ -1,0 +1,22 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Install Script
+# Usage: Double-click this file (on macOS) or run it in Terminal to set up the project.
+# Created: 2025-08-02 – v1.0
+
+echo "🔧 Installing Node.js dependencies (this may take a moment)..."
+npm install
+
+echo "🐘 Setting up the PostgreSQL database (creating tables)..."
+node migrate.js
+
+echo "✅ Installation complete! OFEM is now set up."
+echo "-------------------------------------------------"
+echo "Next steps:"
+echo "1. Start the server with: ./start.command"
+echo "2. Once the server is running, you can test the endpoints."
+echo "   - GET http://localhost:3000/api/fans        (fetch the list of fans)"
+echo "   - POST http://localhost:3000/api/sendMessage (send a personalised message)"
+echo ""
+echo "Happy messaging! 😃"
+
+# End of File – Last modified 2025-08-02

--- a/migrate.js
+++ b/migrate.js
@@ -1,0 +1,45 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate.js
+   Purpose: One-time database setup (create tables for OFEM)
+   Created: 2025-08-02 – v1.0
+*/
+
+const dotenv = require('dotenv');
+dotenv.config();  // Load environment variables (ensure .env is loaded for db.js)
+
+const pool = require('./db');  // Import the database pool from db.js
+
+// Define the SQL query to create the "fans" table with required columns
+const createTableQuery = `
+CREATE TABLE IF NOT EXISTS fans (
+    id BIGINT PRIMARY KEY,
+    username TEXT,
+    name TEXT,
+    parker_name TEXT,
+    is_custom BOOLEAN DEFAULT FALSE,
+    updatedAt TIMESTAMP NOT NULL DEFAULT NOW()
+);
+`;
+
+/*
+ Columns:
+ - id: OnlyFans user ID of the fan (stored as a big integer).
+ - username: the fan's profile username or display name.
+ - name: the fan's account name from OnlyFans.
+ - parker_name: the custom name given to the fan (to personalize messages).
+ - is_custom: flag showing if parker_name was manually set.
+ - updatedAt: timestamp of the last update to this fan record (defaults to now on insert).
+*/
+
+(async () => {
+    try {
+        await pool.query(createTableQuery);
+        console.log('✅ "fans" table has been created (if it did not exist already).');
+    } catch (err) {
+        console.error('Error running migration:', err.message);
+    } finally {
+        await pool.end();
+    }
+})();
+
+/* End of File – Last modified 2025-08-02 */

--- a/server.js
+++ b/server.js
@@ -6,28 +6,15 @@
 
 const express = require('express');
 const axios = require('axios');
-const { Pool } = require('pg');
 const { Configuration, OpenAIApi } = require('openai');
 const dotenv = require('dotenv');
 dotenv.config();
 
+// Database connection pool
+const pool = require('./db');
+
 const app = express();
 app.use(express.json());
-
-// Database setup
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-
-// Ensure fans table exists
-const initDb = async () => {
-	await pool.query(`CREATE TABLE IF NOT EXISTS fans (
-		id BIGINT PRIMARY KEY,
-		username TEXT,
-		name TEXT,
-		parker_name TEXT,
-		is_custom BOOLEAN DEFAULT FALSE
-	)`);
-	console.log("Database initialized (fans table ready).");
-};
 
 // OnlyFans API client (bearer auth)
 const ofApi = axios.create({
@@ -206,14 +193,10 @@ app.get('/api/fans', async (req, res) => {
 const path = require('path');
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Start the server after initializing DB
-initDb().then(() => {
-	const port = process.env.PORT || 3000;
-	app.listen(port, () => {
-		console.log(`OFEM server listening on http://localhost:${port}`);
-	});
-}).catch(err => {
-	console.error("Failed to start server:", err);
+// Start the server
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+        console.log(`OFEM server listening on http://localhost:${port}`);
 });
 
 /* End of File – Last modified 2025-08-02 */

--- a/start.command
+++ b/start.command
@@ -1,8 +1,8 @@
 #!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Start Script
+# Usage: Double-click this file (on macOS) or run it in Terminal to start the server.
+# Created: 2025-08-02 – v1.0
+
 cd "$(dirname "$0")"
-if [ ! -d "node_modules" ]; then
-  echo "Installing dependencies..."
-  npm install
-fi
 echo "Starting OnlyFans Express Messenger..."
 npm start


### PR DESCRIPTION
## Summary
- add PostgreSQL connection helper that creates the database if needed
- provide migration script for `fans` table and update server to use shared pool
- include install/start scripts and expanded `.env` template

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install`
- `DB_NAME=test_db DB_USER=postgres DB_PASSWORD=postgres DB_HOST=localhost DB_PORT=5432 node migrate.js` *(fails: Error running migration)*
- `DB_NAME=test_db DB_USER=postgres DB_PASSWORD=postgres DB_HOST=localhost DB_PORT=5432 node server.js` *(fails: Error ensuring database exists)*

------
https://chatgpt.com/codex/tasks/task_e_688e6b4e4b90832198b828a4845f3aef