### PR TITLE
fix: restore server header and document database wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ nicknames.
    Copy `.env.example` to `.env` and edit the values for your database, OnlyFans API
    key and OpenAI key.
 
-2. **Install dependencies and set up the database**
+2. **Install dependencies and run the database setup wizard**
 
    ```bash
    ./install.command
    ```
 
-   This script runs `npm install` and executes the migration to create the `fans` table.
+   The script installs Node dependencies and automatically creates the database and `fans` table.
 
 3. **Start the server**
 

--- a/server.js
+++ b/server.js
@@ -14,6 +14,11 @@ dotenv.config();
 const pool = require('./db');
 
 const app = express();
+app.disable('x-powered-by');
+app.use((req, res, next) => {
+        res.setHeader('Server', 'OFEM');
+        next();
+});
 app.use(express.json());
 
 // OnlyFans API client (bearer auth)


### PR DESCRIPTION
## Summary
- disable Express's default header and emit a custom `Server: OFEM` header
- explain the automatic database setup wizard in the README install instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e82ae9cac83219eeaeba053f10797