### PR TITLE
feat: add automated database setup wizard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ DB_PORT=5432                      # Port number (5432 is default for PostgreSQL)
 
 # Express server port
 PORT=3000                         # Port for the Express server (defaults to 3000)
+
+# Optional: admin credentials for setup wizard (if your PostgreSQL requires them)
+# DB_ADMIN_USER=postgres
+# DB_ADMIN_PASSWORD=your_postgres_admin_password

--- a/README.md
+++ b/README.md
@@ -18,24 +18,32 @@ nicknames.
 ## Prerequisites
 
 - Node.js 14+
-- PostgreSQL (credentials provided in `.env`)
+- PostgreSQL (PostgreSQL App works great on macOS)
 - OnlyFans API key
 - OpenAI API key
 
 ## Setup
 
-1. **Configure environment**
-
-   Copy `.env.example` to `.env` and edit the values for your database, OnlyFans API
-   key and OpenAI key.
-
-2. **Install dependencies and run the database setup wizard**
+1. **Install dependencies**
 
    ```bash
    ./install.command
    ```
 
-   The script installs Node dependencies and automatically creates the database and `fans` table.
+2. **Create the database automatically**
+
+   Double‑click `predeploy.html` and press **Set up new database**. A Terminal window
+   opens, creates the database, and updates your `.env` file with random credentials.
+   Keep the window open until it says “Database setup complete!”, then open `.env`
+   and fill in your OnlyFans and OpenAI API keys.
+
+   If you already have a PostgreSQL database configured, you can instead run:
+
+   ```bash
+   node migrate.js
+   ```
+
+   This creates the required `fans` table using your existing credentials.
 
 3. **Start the server**
 
@@ -65,4 +73,3 @@ nicknames.
   to allow further expansion.
 
 <!-- End of File – Last modified 2025-08-02 -->
-

--- a/install.command
+++ b/install.command
@@ -1,21 +1,28 @@
 #!/bin/bash
+# Exit on first error
+set -e
 # OnlyFans Express Messenger (OFEM) - Install Script
 # Usage: Double-click this file (on macOS) or run it in Terminal to set up the project.
 # Created: 2025-08-02 – v1.0
 
+cd "$(dirname "$0")"
 echo "🔧 Installing Node.js dependencies (this may take a moment)..."
 npm install
 
-echo "🐘 Setting up the PostgreSQL database (creating tables)..."
-node migrate.js
+if [ -f .env ]; then
+  echo "🐘 Running database migrations..."
+  if node migrate.js; then
+    echo "Database is ready."
+  else
+    echo "Skipping migrations (database not yet configured)."
+  fi
+fi
 
-echo "✅ Installation complete! OFEM is now set up."
+echo "✅ Installation complete!"
 echo "-------------------------------------------------"
 echo "Next steps:"
-echo "1. Start the server with: ./start.command"
-echo "2. Once the server is running, you can test the endpoints."
-echo "   - GET http://localhost:3000/api/fans        (fetch the list of fans)"
-echo "   - POST http://localhost:3000/api/sendMessage (send a personalised message)"
+echo "1. If you haven't created the database yet, open predeploy.html and click 'Set up new database'."
+echo "2. Start the server with: ./start.command"
 echo ""
 echo "Happy messaging! 😃"
 

--- a/predeploy.html
+++ b/predeploy.html
@@ -6,16 +6,17 @@
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.5; }
     ol { max-width: 700px; }
+    button { padding: 10px 16px; font-size: 16px; cursor: pointer; }
   </style>
 </head>
 <body>
   <h1>Getting Started with OFEM</h1>
-  <p>Follow these steps on a Mac to run OFEM for the first time. No programming knowledge required.</p>
+  <p>Follow these simple steps on a Mac to run OFEM. No programming knowledge required.</p>
   <ol>
     <li><strong>Install Requirements</strong>
       <ol>
         <li>Install <a href="https://nodejs.org/">Node.js</a> (LTS version) and follow the installer prompts.</li>
-        <li>Install <a href="https://postgresapp.com/">PostgreSQL</a> (or another PostgreSQL distribution) and start the database server.</li>
+        <li>Ensure the PostgreSQL App is running (it's already installed).</li>
       </ol>
     </li>
     <li><strong>Download and Unzip</strong>
@@ -24,29 +25,21 @@
         <li>Open your Downloads folder and double‑click the ZIP to create the <code>OFEM</code> folder.</li>
       </ol>
     </li>
-    <li><strong>Create the Configuration File</strong>
+    <li><strong>Install Packages</strong>
       <ol>
-        <li>Open the <code>OFEM</code> folder and find <code>.env.example</code>.</li>
-        <li>Make a copy of it named <code>.env</code>.</li>
-        <li>Open <code>.env</code> with TextEdit and replace the placeholder values:
-          <ul>
-            <li><code>DATABASE_URL</code> – your PostgreSQL connection string (for example <code>postgres://user:password@localhost:5432/ofem</code>).</li>
-            <li><code>ONLYFANS_API_KEY</code> – your OnlyFans API key.</li>
-            <li><code>OPENAI_API_KEY</code> – your OpenAI API key.</li>
-          </ul>
-        </li>
-        <li>Save the file.</li>
+        <li>In the <code>OFEM</code> folder, double‑click <code>install.command</code>. It installs everything you need.</li>
       </ol>
     </li>
-    <li><strong>Prepare the Database</strong>
+    <li><strong>Create the Database</strong>
       <ol>
-        <li>If the database named in <code>DATABASE_URL</code> does not exist, create it using the PostgreSQL app or run <code>createdb ofem</code> in Terminal.</li>
+        <li>Click the button below. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='setup-db.command'">Set up new database</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">Leave the Terminal window open until it shows “Database setup complete!”.</li>
       </ol>
     </li>
     <li><strong>Run the App</strong>
       <ol>
-        <li>In the <code>OFEM</code> folder, double‑click <code>start.command</code>. A Terminal window opens.</li>
-        <li>The script installs needed packages (only the first time) and starts the server.</li>
+        <li>Double‑click <code>start.command</code> to launch the server.</li>
       </ol>
     </li>
     <li><strong>Open the Dashboard</strong>
@@ -56,6 +49,6 @@
       </ol>
     </li>
   </ol>
-  <p>The app is now ready. Use the buttons in the dashboard to update fan names and send messages.</p>
+  <p>The app is now ready. Use the dashboard buttons to update fan names and send messages.</p>
 </body>
 </html>

--- a/setup-db.command
+++ b/setup-db.command
@@ -1,0 +1,9 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Database Setup Wizard
+# Usage: Double-click this file (on macOS) or run it in Terminal to create a new database.
+# Created: 2025-08-02 – v1.0
+
+set -e
+cd "$(dirname "$0")"
+node setup-db.js
+

--- a/setup-db.js
+++ b/setup-db.js
@@ -1,0 +1,114 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: setup-db.js
+   Purpose: One-click database setup wizard
+   Created: 2025-08-02 – v1.0
+*/
+
+const { Client } = require('pg');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const createTableQuery = `
+CREATE TABLE IF NOT EXISTS fans (
+    id BIGINT PRIMARY KEY,
+    username TEXT,
+    name TEXT,
+    parker_name TEXT,
+    is_custom BOOLEAN DEFAULT FALSE,
+    updatedAt TIMESTAMP NOT NULL DEFAULT NOW()
+);
+`;
+
+async function main() {
+    try {
+        console.log('🧙 Starting database setup wizard...');
+        const dbName = 'ofem_' + crypto.randomBytes(4).toString('hex');
+        const dbUser = 'user_' + crypto.randomBytes(4).toString('hex');
+        const dbPassword = crypto.randomBytes(10).toString('hex');
+        console.log(`Generated database name: ${dbName}`);
+        console.log(`Generated user: ${dbUser}`);
+
+        // Step 1: connect as admin user
+        const adminConfig = {
+            user: process.env.DB_ADMIN_USER || 'postgres',
+            host: process.env.DB_HOST || 'localhost',
+            port: process.env.DB_PORT || 5432,
+            database: 'postgres'
+        };
+        if (process.env.DB_ADMIN_PASSWORD) {
+            adminConfig.password = process.env.DB_ADMIN_PASSWORD;
+        }
+
+        console.log('Connecting to PostgreSQL...');
+        const adminClient = new Client(adminConfig);
+        try {
+            await adminClient.connect();
+        } catch (err) {
+            throw new Error('Could not connect to PostgreSQL. Is it running?');
+        }
+        await adminClient.query(`CREATE USER "${dbUser}" WITH PASSWORD '${dbPassword}'`);
+        await adminClient.query(`CREATE DATABASE "${dbName}" OWNER "${dbUser}"`);
+        await adminClient.end();
+        console.log('Database and user created.');
+
+        // Step 2: create table in the new database
+        const newClient = new Client({
+            user: dbUser,
+            password: dbPassword,
+            host: adminConfig.host,
+            port: adminConfig.port,
+            database: dbName
+        });
+        await newClient.connect();
+        await newClient.query(createTableQuery);
+        await newClient.end();
+        console.log('Fans table created.');
+
+        // Step 3: update .env with new credentials, preserving other values
+        const envPath = path.join(__dirname, '.env');
+        const exampleEnvPath = path.join(__dirname, '.env.example');
+        if (!fs.existsSync(envPath) && fs.existsSync(exampleEnvPath)) {
+            fs.copyFileSync(exampleEnvPath, envPath);
+        }
+        let envContent = '';
+        if (fs.existsSync(envPath)) {
+            envContent = fs.readFileSync(envPath, 'utf8');
+        }
+        const setEnv = (key, value) => {
+            const regex = new RegExp(`^${key}=.*$`, 'm');
+            if (regex.test(envContent)) {
+                envContent = envContent.replace(regex, `${key}=${value}`);
+            } else {
+                envContent += `\n${key}=${value}`;
+            }
+        };
+        const ensureEnv = (key, value) => {
+            const regex = new RegExp(`^${key}=.*$`, 'm');
+            if (!regex.test(envContent)) {
+                envContent += `\n${key}=${value}`;
+            }
+        };
+        setEnv('DB_NAME', dbName);
+        setEnv('DB_USER', dbUser);
+        setEnv('DB_PASSWORD', dbPassword);
+        ensureEnv('DB_HOST', adminConfig.host);
+        ensureEnv('DB_PORT', adminConfig.port);
+        if (!envContent.endsWith('\n')) envContent += '\n';
+        fs.writeFileSync(envPath, envContent);
+        console.log('.env file updated.');
+
+        console.log('✅ Database setup complete!');
+        console.log(`   DB_NAME=${dbName}`);
+        console.log(`   DB_USER=${dbUser}`);
+        console.log(`   DB_PASSWORD=${dbPassword}`);
+        console.log('Add your API keys to .env and run ./start.command to launch the app.');
+    } catch (err) {
+        console.error('❌ Setup failed:', err.message || err);
+        process.exit(1);
+    }
+}
+
+main();
+
+/* End of File – Last modified 2025-08-02 */

--- a/start.command
+++ b/start.command
@@ -3,6 +3,9 @@
 # Usage: Double-click this file (on macOS) or run it in Terminal to start the server.
 # Created: 2025-08-02 – v1.0
 
+set -e
 cd "$(dirname "$0")"
 echo "Starting OnlyFans Express Messenger..."
+echo "Press Ctrl+C to stop the server."
 npm start
+


### PR DESCRIPTION
## Summary
- add optional PostgreSQL admin credential placeholders to `.env.example`
- document one-click database setup wizard and new start/install scripts
- include setup wizard scripts and styled predeploy helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install`
- `node setup-db.js` *(fails: Could not connect to PostgreSQL. Is it running?)*
- `npm start` *(fails: Error ensuring database exists)*

------
https://chatgpt.com/codex/tasks/task_e_688e85fa14248321b3b9494ebef25fcd