### PR TITLE
feat: add one-click node setup

### DIFF
--- a/install-node.command
+++ b/install-node.command
@@ -1,0 +1,22 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Node.js Install Script
+# Downloads the latest LTS version of Node.js and installs project dependencies.
+set -e
+cd "$(dirname "$0")"
+
+NODE_INDEX="https://nodejs.org/dist/latest-lts/"
+NODE_PKG=$(curl -fsSL "$NODE_INDEX" | grep -o 'node-v[0-9\.]*\.pkg' | head -1)
+NODE_VERSION=${NODE_PKG#node-v}
+NODE_VERSION=${NODE_VERSION%.pkg}
+
+echo "📦 Downloading Node.js $NODE_VERSION (LTS)..."
+curl -fsSL "${NODE_INDEX}${NODE_PKG}" -o "$NODE_PKG"
+
+echo "⚙️ Installing Node.js..."
+sudo installer -pkg "$NODE_PKG" -target /
+rm "$NODE_PKG"
+
+echo "📚 Installing npm packages..."
+npm install
+
+echo "✅ Node.js and packages installed successfully."

--- a/predeploy.html
+++ b/predeploy.html
@@ -15,7 +15,10 @@
   <ol>
     <li><strong>Install Requirements</strong>
       <ol>
-        <li>Install <a href="https://nodejs.org/">Node.js</a> (LTS version) and follow the installer prompts.</li>
+        <li>Click the button below to install Node.js (LTS) in this folder and download all required npm packages.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='install-node.command'">Install Node at Folder</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-node.command</code> manually.</li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">You may be asked for your macOS password to complete the installation.</li>
         <li>Install <a href="https://www.docker.com/products/docker-desktop/">Docker Desktop</a> and make sure it is running.<br>If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
       </ol>
     </li>
@@ -23,11 +26,6 @@
       <ol>
         <li>Download the project ZIP file.</li>
         <li>Open your Downloads folder and double‑click the ZIP to create the <code>OFEM</code> folder.</li>
-      </ol>
-    </li>
-    <li><strong>Install Packages</strong>
-      <ol>
-        <li>In the <code>OFEM</code> folder, double‑click <code>install.command</code>. It installs everything you need.</li>
       </ol>
     </li>
     <li><strong>Create the Database</strong>


### PR DESCRIPTION
## Summary
- provide predeploy button to install Node.js LTS and dependencies automatically
- add script to download & install Node.js LTS and run npm install

## Testing
- `npm test` (fails: Missing script "test")
- `bash -n install-node.command`


------
https://chatgpt.com/codex/tasks/task_e_688e9e1fce88832181c41b86cb663a5c