### PR TITLE
Ensure macOS Apple Silicon Docker install and command quarantine helper

### DIFF
--- a/install-docker.command
+++ b/install-docker.command
@@ -3,24 +3,23 @@ set -e
 
 OS=$(uname)
 
-if [[ "$OS" == "Darwin" ]]; then
-  echo "Downloading Docker Desktop for macOS..."
-  curl -L https://desktop.docker.com/mac/main/amd64/Docker.dmg -o Docker.dmg
-  hdiutil attach Docker.dmg
-  cp -R /Volumes/Docker/Docker.app /Applications
-  hdiutil detach /Volumes/Docker
-  open /Applications/Docker.app
-  echo "Docker Desktop installed."
-elif [[ "$OS" == "Linux" ]]; then
-  echo "Installing Docker Engine using convenience script..."
-  curl -fsSL https://get.docker.com | sh
-  echo "Docker Engine installed. Please log out and back in to start using Docker."
-elif [[ "$OS" =~ MINGW64_NT|MSYS_NT|CYGWIN_NT ]]; then
-  echo "Downloading Docker Desktop for Windows..."
-  curl -L "https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe" -o DockerDesktopInstaller.exe
-  echo "Launching Docker Desktop installer..."
-  start "" DockerDesktopInstaller.exe
-else
+if [[ "$OS" != "Darwin" ]]; then
   echo "Unsupported OS: $OS"
   exit 1
 fi
+
+ARCH=$(uname -m)
+if [[ "$ARCH" != "arm64" ]]; then
+  echo "This is the Intel version of Docker Desktop"
+  echo "Please download the latest Apple Silicon build from"
+  echo "https://desktop.docker.com/mac/main/arm64/Docker.dmg"
+  exit 1
+fi
+
+echo "Downloading Docker Desktop for macOS (Apple Silicon)..."
+curl -L https://desktop.docker.com/mac/main/arm64/Docker.dmg -o Docker.dmg
+hdiutil attach Docker.dmg
+cp -R /Volumes/Docker/Docker.app /Applications
+hdiutil detach /Volumes/Docker
+open /Applications/Docker.app
+echo "Docker Desktop installed."

--- a/predeploy.html
+++ b/predeploy.html
@@ -13,6 +13,19 @@
   <h1>Getting Started with OFEM</h1>
   <p>Follow these simple steps on a Mac to run OFEM. No programming knowledge required.</p>
   <ol>
+    <li><strong>Download and Unzip</strong>
+      <ol>
+        <li>Download the project ZIP file.</li>
+        <li>Open your Downloads folder and double‑click the ZIP to create the <code>OFEM</code> folder.</li>
+      </ol>
+    </li>
+    <li><strong>Allow Scripts to Run</strong>
+      <ol>
+        <li>Click the button below to remove the quarantine flag from the command files.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='remove-quarantine.command'">Allow command files</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>remove-quarantine.command</code> manually.</li>
+      </ol>
+    </li>
     <li><strong>Install Requirements</strong>
       <ol>
         <li>Click the button below to install Node.js (LTS) in this folder and download all required npm packages.</li>
@@ -23,12 +36,6 @@
         <li style="margin-top:8px;"><button onclick="window.location.href='install-docker.command'">Install Docker Desktop</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
-      </ol>
-    </li>
-    <li><strong>Download and Unzip</strong>
-      <ol>
-        <li>Download the project ZIP file.</li>
-        <li>Open your Downloads folder and double‑click the ZIP to create the <code>OFEM</code> folder.</li>
       </ol>
     </li>
     <li><strong>Create the Database</strong>

--- a/remove-quarantine.command
+++ b/remove-quarantine.command
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Remove the macOS quarantine attribute from command files
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+xattr -d com.apple.quarantine "$DIR/install.command" 2>/dev/null || true
+xattr -d com.apple.quarantine "$DIR/install-node.command" 2>/dev/null || true
+xattr -d com.apple.quarantine "$DIR/install-docker.command" 2>/dev/null || true
+xattr -d com.apple.quarantine "$DIR/setup-db.command" 2>/dev/null || true
+xattr -d com.apple.quarantine "$DIR/start.command" 2>/dev/null || true
+xattr -d com.apple.quarantine "$DIR/remove-quarantine.command" 2>/dev/null || true
+
+echo "Quarantine flags removed from command files."


### PR DESCRIPTION
## Summary
- Ensure Docker installation script targets Apple Silicon Macs and errors on Intel versions.
- Add helper script and documentation to remove macOS quarantine flags from .command files.
- Update pre-deploy guide to include quarantine removal step and reorder setup instructions.

## Testing
- `bash -n install-docker.command`
- `bash -n remove-quarantine.command`
- `for f in install.command install-node.command setup-db.command start.command; do bash -n "$f"; done`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ea7eeb4348321b4e56ee797c1e449