### PR TITLE
feat: add env setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ nicknames.
 
 2. **Configure environment**
 
-   Copy `.env.example` to `.env` and edit the values for your database, OnlyFans API
-   key and OpenAI key.
+   Run `./setup-env.command` (macOS) or `node setup-env.js` to enter your OnlyFans and
+   OpenAI API keys. This creates a `.env` file. The database setup wizard will add the
+   database credentials later.
 
 3. **Start PostgreSQL (Docker)**
 

--- a/predeploy.html
+++ b/predeploy.html
@@ -38,6 +38,13 @@
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
       </ol>
     </li>
+    <li><strong>Add API Keys</strong>
+      <ol>
+        <li>Click the button below to enter your OnlyFans and OpenAI API keys. This creates your <code>.env</code> file.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='setup-env.command'">Configure API keys</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>setup-env.command</code> manually.</li>
+      </ol>
+    </li>
     <li><strong>Create the Database</strong>
       <ol>
         <li>Click the button below. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</li>

--- a/setup-env.command
+++ b/setup-env.command
@@ -1,0 +1,9 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Environment Setup Wizard
+# Usage: Double-click this file (on macOS) or run it in Terminal to create/update .env with API keys.
+# Created: 2025-08-05 – v1.0
+
+set -e
+cd "$(dirname "$0")"
+node setup-env.js
+

--- a/setup-env.js
+++ b/setup-env.js
@@ -1,0 +1,57 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: setup-env.js
+   Purpose: Wizard to collect API keys and create .env file
+   Created: 2025-08-05 – v1.0
+*/
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+async function prompt(question) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise(resolve => rl.question(question, answer => {
+        rl.close();
+        resolve(answer.trim());
+    }));
+}
+
+async function main() {
+    const envPath = path.join(__dirname, '.env');
+    const exampleEnvPath = path.join(__dirname, '.env.example');
+
+    // Ensure .env exists, copying from example if available
+    if (!fs.existsSync(envPath)) {
+        if (fs.existsSync(exampleEnvPath)) {
+            fs.copyFileSync(exampleEnvPath, envPath);
+        } else {
+            fs.writeFileSync(envPath, '');
+        }
+    }
+
+    let envContent = fs.readFileSync(envPath, 'utf8');
+
+    const onlyfansKey = await prompt('Enter your OnlyFans API Key (leave blank to skip): ');
+    const openaiKey = await prompt('Enter your OpenAI API Key (leave blank to skip): ');
+
+    const setEnv = (key, value) => {
+        if (!value) return;
+        const regex = new RegExp(`^${key}=.*$`, 'm');
+        if (regex.test(envContent)) {
+            envContent = envContent.replace(regex, `${key}=${value}`);
+        } else {
+            envContent += `\n${key}=${value}`;
+        }
+    };
+
+    setEnv('ONLYFANS_API_KEY', onlyfansKey);
+    setEnv('OPENAI_API_KEY', openaiKey);
+    if (!envContent.endsWith('\n')) envContent += '\n';
+    fs.writeFileSync(envPath, envContent);
+    console.log('.env file created/updated.');
+    console.log('Next run setup-db.command to create the database.');
+}
+
+main();
+
+/* End of File – Last modified 2025-08-05 */


### PR DESCRIPTION
## Summary
- add `setup-env.js` wizard to collect API keys and build `.env`
- document API key step in README and predeploy guide
- include `setup-env.command` to launch the wizard on macOS

## Testing
- `npm test` *(fails: Missing script "test")*
- `node setup-env.js`


------
https://chatgpt.com/codex/tasks/task_e_688eaaae3ed48321adf626e79d50a037