### PR TITLE
feat: add env setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,14 @@ nicknames.
 
 2. **Configure environment**
 
-   Copy `.env.example` to `.env` and edit the values for your database, OnlyFans API
-   key and OpenAI key.
+   Run `./setup-env.command` (macOS) or `node setup-env.js` to enter your OnlyFans and
+   OpenAI API keys. This creates a `.env` file. The database setup wizard will add the
+   database credentials later.
 
-3. **Start PostgreSQL (Docker)**
+3. **Create the database**
 
-   A `docker-compose.yml` is provided to launch a local database quickly:
-
-   ```bash
-   docker compose up -d db
-   ```
-
-   The default connection string is
-   `postgres://postgres:postgres@localhost:5432/ofdb`.
+   Run `./setup-db.command` (macOS) or `node setup-db.js` to spin up PostgreSQL via Docker (if needed),
+   create a database with a random name, and write the credentials to your `.env` file.
 
 4. **Start the server**
 
@@ -53,7 +48,7 @@ nicknames.
    ```
 
    The server listens on <http://localhost:3000> by default.  A convenience script
-   `start.command` (macOS) runs `npm install` if needed and then launches the server.
+   `start.command` (macOS) installs npm packages if required and then launches the server.
 
 ## Usage
 

--- a/predeploy.html
+++ b/predeploy.html
@@ -21,7 +21,7 @@
     </li>
     <li><strong>Allow Scripts to Run</strong>
       <ol>
-        <li>Click the button below to remove the quarantine flag from the command files.</li>
+        <li>Click the button below to remove the quarantine flag from all <code>.command</code> files (install, setup-env, setup-db, start, etc.).</li>
         <li style="margin-top:8px;"><button onclick="window.location.href='remove-quarantine.command'">Allow command files</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>remove-quarantine.command</code> manually.</li>
       </ol>
@@ -36,6 +36,13 @@
         <li style="margin-top:8px;"><button onclick="window.location.href='install-docker.command'">Install Docker Desktop</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
+      </ol>
+    </li>
+    <li><strong>Add API Keys</strong>
+      <ol>
+        <li>Click the button below to enter your OnlyFans and OpenAI API keys. This creates your <code>.env</code> file.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='setup-env.command'">Configure API keys</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>setup-env.command</code> manually.</li>
       </ol>
     </li>
     <li><strong>Create the Database</strong>

--- a/remove-quarantine.command
+++ b/remove-quarantine.command
@@ -3,11 +3,8 @@
 set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-xattr -d com.apple.quarantine "$DIR/install.command" 2>/dev/null || true
-xattr -d com.apple.quarantine "$DIR/install-node.command" 2>/dev/null || true
-xattr -d com.apple.quarantine "$DIR/install-docker.command" 2>/dev/null || true
-xattr -d com.apple.quarantine "$DIR/setup-db.command" 2>/dev/null || true
-xattr -d com.apple.quarantine "$DIR/start.command" 2>/dev/null || true
-xattr -d com.apple.quarantine "$DIR/remove-quarantine.command" 2>/dev/null || true
+for f in "$DIR"/*.command; do
+  xattr -d com.apple.quarantine "$f" 2>/dev/null || true
+done
 
 echo "Quarantine flags removed from command files."

--- a/setup-db.js
+++ b/setup-db.js
@@ -127,31 +127,21 @@ async function main() {
         if (!fs.existsSync(envPath) && fs.existsSync(exampleEnvPath)) {
             fs.copyFileSync(exampleEnvPath, envPath);
         }
-        let envContent = '';
+        let lines = [];
         if (fs.existsSync(envPath)) {
-            envContent = fs.readFileSync(envPath, 'utf8');
+            const existing = fs.readFileSync(envPath, 'utf8');
+            lines = existing.split(/\r?\n/).filter(line => !line.startsWith('DB_NAME=') &&
+                !line.startsWith('DB_USER=') &&
+                !line.startsWith('DB_PASSWORD=') &&
+                !line.startsWith('DB_HOST=') &&
+                !line.startsWith('DB_PORT='));
         }
-        const setEnv = (key, value) => {
-            const regex = new RegExp(`^${key}=.*$`, 'm');
-            if (regex.test(envContent)) {
-                envContent = envContent.replace(regex, `${key}=${value}`);
-            } else {
-                envContent += `\n${key}=${value}`;
-            }
-        };
-        const ensureEnv = (key, value) => {
-            const regex = new RegExp(`^${key}=.*$`, 'm');
-            if (!regex.test(envContent)) {
-                envContent += `\n${key}=${value}`;
-            }
-        };
-        setEnv('DB_NAME', dbName);
-        setEnv('DB_USER', dbUser);
-        setEnv('DB_PASSWORD', dbPassword);
-        ensureEnv('DB_HOST', adminConfig.host);
-        ensureEnv('DB_PORT', adminConfig.port);
-        if (!envContent.endsWith('\n')) envContent += '\n';
-        fs.writeFileSync(envPath, envContent);
+        lines.push(`DB_NAME=${dbName}`);
+        lines.push(`DB_USER=${dbUser}`);
+        lines.push(`DB_PASSWORD=${dbPassword}`);
+        lines.push(`DB_HOST=${adminConfig.host}`);
+        lines.push(`DB_PORT=${adminConfig.port}`);
+        fs.writeFileSync(envPath, lines.join('\n') + '\n');
         console.log('.env file updated.');
 
         console.log('✅ Database setup complete!');

--- a/setup-env.command
+++ b/setup-env.command
@@ -1,0 +1,9 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Environment Setup Wizard
+# Usage: Double-click this file (on macOS) or run it in Terminal to create/update .env with API keys.
+# Created: 2025-08-05 – v1.0
+
+set -e
+cd "$(dirname "$0")"
+node setup-env.js
+

--- a/setup-env.js
+++ b/setup-env.js
@@ -1,0 +1,57 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: setup-env.js
+   Purpose: Wizard to collect API keys and create .env file
+   Created: 2025-08-05 – v1.0
+*/
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+async function prompt(question) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise(resolve => rl.question(question, answer => {
+        rl.close();
+        resolve(answer.trim());
+    }));
+}
+
+async function main() {
+    const envPath = path.join(__dirname, '.env');
+    const exampleEnvPath = path.join(__dirname, '.env.example');
+
+    // Ensure .env exists, copying from example if available
+    if (!fs.existsSync(envPath)) {
+        if (fs.existsSync(exampleEnvPath)) {
+            fs.copyFileSync(exampleEnvPath, envPath);
+        } else {
+            fs.writeFileSync(envPath, '');
+        }
+    }
+
+    let envContent = fs.readFileSync(envPath, 'utf8');
+
+    const onlyfansKey = await prompt('Enter your OnlyFans API Key (leave blank to skip): ');
+    const openaiKey = await prompt('Enter your OpenAI API Key (leave blank to skip): ');
+
+    const setEnv = (key, value) => {
+        if (!value) return;
+        const regex = new RegExp(`^${key}=.*$`, 'm');
+        if (regex.test(envContent)) {
+            envContent = envContent.replace(regex, `${key}=${value}`);
+        } else {
+            envContent += `\n${key}=${value}`;
+        }
+    };
+
+    setEnv('ONLYFANS_API_KEY', onlyfansKey);
+    setEnv('OPENAI_API_KEY', openaiKey);
+    if (!envContent.endsWith('\n')) envContent += '\n';
+    fs.writeFileSync(envPath, envContent);
+    console.log('.env file created/updated.');
+    console.log('Next run setup-db.command to create the database.');
+}
+
+main();
+
+/* End of File – Last modified 2025-08-05 */

--- a/start.command
+++ b/start.command
@@ -7,5 +7,12 @@ set -e
 cd "$(dirname "$0")"
 echo "Starting OnlyFans Express Messenger..."
 echo "Press Ctrl+C to stop the server."
+
+# Install dependencies if pg (PostgreSQL client) is missing
+if ! node -e "require('pg')" >/dev/null 2>&1; then
+  echo "Installing npm packages..."
+  npm install
+fi
+
 npm start
 


### PR DESCRIPTION
## Summary
- ensure `setup-db` reliably writes generated database credentials to `.env`
- auto-install missing npm packages when running `start.command`
- allow macOS quarantine removal for all `*.command` helpers and document the updated setup flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `node setup-db.js` *(fails: Docker is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688eaaae3ed48321adf626e79d50a037