### PR TITLE
fix: ensure setup scripts install dependencies

### DIFF
--- a/setup-db.command
+++ b/setup-db.command
@@ -5,5 +5,15 @@
 
 set -e
 cd "$(dirname "$0")"
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but not installed. Please install Node.js." >&2
+  exit 1
+fi
+
+if [ ! -d node_modules/pg ]; then
+  echo "Installing Node dependencies..."
+  npm install >/dev/null
+fi
+
 node setup-db.js
 


### PR DESCRIPTION
## Summary
- install Node dependencies when running setup-db.command
- fetch the latest LTS release in install-node.command to avoid 404s

## Testing
- `bash install-node.command` *(fails: installer command not found; skipping Node.js installation)*
- `bash setup-db.command` *(fails: Could not connect to PostgreSQL. Is it running?)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688eb5faaf848321ab7f854161218bdb