### PR TITLE
docs: mention project installer

### DIFF
--- a/predeploy.html
+++ b/predeploy.html
@@ -36,6 +36,9 @@
         <li style="margin-top:8px;"><button onclick="window.location.href='install-docker.command'">Install Docker Desktop</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
+        <li>Once Node and Docker are installed, run the project installer below to download any remaining packages and run initial database setup.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='install.command'">Run installer</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install.command</code> manually.</li>
       </ol>
     </li>
     <li><strong>Add API Keys</strong>


### PR DESCRIPTION
## Summary
- mention `install.command` in pre-deploy guide so users run main installer after Node and Docker setup

## Testing
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688eba4c8d508321b08ec12e24ef1453