### PR TITLE
feat: install docker via homebrew

### DIFF
--- a/install-docker.command
+++ b/install-docker.command
@@ -1,25 +1,21 @@
 #!/usr/bin/env bash
+# OnlyFans Express Messenger (OFEM) - Docker Install Script
+# Installs Docker Desktop using Homebrew.
 set -e
+cd "$(dirname "$0")"
 
 OS=$(uname)
-
 if [[ "$OS" != "Darwin" ]]; then
   echo "Unsupported OS: $OS"
   exit 1
 fi
 
-ARCH=$(uname -m)
-if [[ "$ARCH" != "arm64" ]]; then
-  echo "This is the Intel version of Docker Desktop"
-  echo "Please download the latest Apple Silicon build from"
-  echo "https://desktop.docker.com/mac/main/arm64/Docker.dmg"
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Please install Homebrew from https://brew.sh"
   exit 1
 fi
 
-echo "Downloading Docker Desktop for macOS (Apple Silicon)..."
-curl -L https://desktop.docker.com/mac/main/arm64/Docker.dmg -o Docker.dmg
-hdiutil attach Docker.dmg
-cp -R /Volumes/Docker/Docker.app /Applications
-hdiutil detach /Volumes/Docker
-open /Applications/Docker.app
+echo "Installing Docker Desktop via Homebrew..."
+brew install --cask docker
+open -a Docker || open /Applications/Docker.app
 echo "Docker Desktop installed."

--- a/predeploy.html
+++ b/predeploy.html
@@ -32,9 +32,9 @@
         <li style="margin-top:8px;"><button onclick="window.location.href='install-node.command'">Install Node at Folder</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-node.command</code> manually.</li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">You may be asked for your macOS password to complete the installation.</li>
-        <li>Click the button below to install Docker Desktop automatically.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='install-docker.command'">Install Docker Desktop</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
+        <li>Click the button below to install Docker Desktop using Homebrew.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='install-docker.command'">Install Docker</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">This opens Terminal in the <code>OFEM</code> folder and runs <code>brew install --cask docker</code>. If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
         <li>Once Node and Docker are installed, run the project installer below to download any remaining packages and run initial database setup.</li>
         <li style="margin-top:8px;"><button onclick="window.location.href='install.command'">Run installer</button></li>


### PR DESCRIPTION
## Summary
- install Docker Desktop via Homebrew instead of manual DMG copy
- update predeploy guide to launch Homebrew Docker install

## Testing
- `bash install-docker.command`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ebb1f3584832199235b6b98ec5f6f