### PR TITLE
Fix OnlyFans fan pagination loop

### DIFF
--- a/server.js
+++ b/server.js
@@ -126,7 +126,8 @@ app.post('/api/updateFans', async (req, res) => {
                 console.log(`Using OnlyFans account: ${OFAccountId}`);
 
                 // 2. Fetch all fans (active + expired subscribers)
-                const limit = 50;
+                // OnlyFans API appears to cap page size at 32 items
+                const limit = 32;
                 const fetchFans = async (type) => {
                         const results = [];
                         let offset = 0;
@@ -135,8 +136,7 @@ app.post('/api/updateFans', async (req, res) => {
                                 const page = resp.data?.data?.list || resp.data?.list || resp.data;
                                 if (!page || page.length === 0) break;
                                 results.push(...page);
-                                if (page.length < limit) break;
-                                offset += limit;
+                                offset += page.length;
                         }
                         return results;
                 };


### PR DESCRIPTION
## Summary
- fetch all fan pages until the API returns no more results
- increment pagination offset by the size of each page and use API's 32 item max

## Testing
- `npm test` *(fails: Missing script "test")*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_688ed8af44408321a124d811f7fdefa0