### PR TITLE
chore: validate api keys before updating fans

### DIFF
--- a/server.js
+++ b/server.js
@@ -137,8 +137,15 @@ function ensureValidParkerName(name, username, profileName) {
 
 /* Story 1: Update Fan Names – Fetch fans from OnlyFans and generate display names using GPT-4. */
 app.post('/api/updateFans', async (req, res) => {
-	try {
-		// 1. Verify API key and get connected account ID
+        const missing = [];
+        if (!process.env.ONLYFANS_API_KEY) missing.push('ONLYFANS_API_KEY');
+        if (!process.env.OPENAI_API_KEY) missing.push('OPENAI_API_KEY');
+        if (missing.length) {
+                return res.status(400).json({ error: `Missing environment variable(s): ${missing.join(', ')}` });
+        }
+
+        try {
+                // 1. Verify API key and get connected account ID
                 const accountsResp = await ofApiRequest(() => ofApi.get('/accounts'));
                 const rawAccounts = accountsResp.data?.data || accountsResp.data;
                 const accounts = Array.isArray(rawAccounts) ? rawAccounts : rawAccounts?.accounts || [];


### PR DESCRIPTION
## Summary
- check for ONLYFANS_API_KEY and OPENAI_API_KEY at the start of `/api/updateFans`
- return a descriptive 400 error if either key is missing

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ee015e8508321ab38cdad62440fc9