### PR TITLE
feat(api): return full fan metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ nicknames.
 5. Click **Send Personalised DM to All Fans** to start sending.  Use **Abort Sending**
    to stop early.
 
+## API
+
+### `GET /api/fans`
+
+Returns a JSON object with a `fans` array containing all fan records stored in the
+database. Each fan includes:
+
+- `id`, `username`, `name`, `parker_name`, `is_custom`
+- Profile details: `avatar`, `header`, `website`, `location`, `gender`, `birthday`, `about`, `notes`
+- Activity data: `lastSeen`, `joined`, `canReceiveChatMessage`, `canSendChatMessage`
+- Status flags: `isBlocked`, `isMuted`, `isRestricted`, `isHidden`, `isBookmarked`, `isSubscribed`, `isFriend`, `renewedAd`
+- Subscription info: `subscribedBy`, `subscribedOn`, `subscribedUntil`, `subscribedByData`, `subscribedOnData`, `promoOffers`
+- Counts: `tipsSum`, `postsCount`, `photosCount`, `videosCount`, `audiosCount`, `mediaCount`, `subscribersCount`, `favoritesCount`
+- Media fields: `avatarThumbs`, `headerSize`, `headerThumbs`, `listsStates`
+- `updatedAt` timestamp of the last record update
+
+JSONB columns such as `avatarThumbs`, `headerSize`, `headerThumbs`, `listsStates`,
+`subscribedByData`, `subscribedOnData`, and `promoOffers` are returned as objects.
+
 ## Notes
 
 - All OnlyFans and OpenAI requests happen server‑side; API keys are never exposed in the

--- a/server.js
+++ b/server.js
@@ -597,7 +597,54 @@ app.post('/api/sendMessage', async (req, res) => {
 // Endpoint to get all fans from DB (for initial page load if needed)
 app.get('/api/fans', async (req, res) => {
         try {
-                const dbRes = await pool.query('SELECT id, username, name, parker_name FROM fans ORDER BY id');
+                const dbRes = await pool.query(`
+                        SELECT
+                                id,
+                                username,
+                                name,
+                                avatar,
+                                header,
+                                website,
+                                location,
+                                gender,
+                                birthday,
+                                about,
+                                notes,
+                                lastSeen AS "lastSeen",
+                                joined AS "joined",
+                                canReceiveChatMessage AS "canReceiveChatMessage",
+                                canSendChatMessage AS "canSendChatMessage",
+                                isBlocked AS "isBlocked",
+                                isMuted AS "isMuted",
+                                isRestricted AS "isRestricted",
+                                isHidden AS "isHidden",
+                                isBookmarked AS "isBookmarked",
+                                isSubscribed AS "isSubscribed",
+                                subscribedBy AS "subscribedBy",
+                                subscribedOn AS "subscribedOn",
+                                subscribedUntil AS "subscribedUntil",
+                                renewedAd AS "renewedAd",
+                                isFriend AS "isFriend",
+                                tipsSum AS "tipsSum",
+                                postsCount AS "postsCount",
+                                photosCount AS "photosCount",
+                                videosCount AS "videosCount",
+                                audiosCount AS "audiosCount",
+                                mediaCount AS "mediaCount",
+                                subscribersCount AS "subscribersCount",
+                                favoritesCount AS "favoritesCount",
+                                avatarThumbs AS "avatarThumbs",
+                                headerSize AS "headerSize",
+                                headerThumbs AS "headerThumbs",
+                                listsStates AS "listsStates",
+                                subscribedByData AS "subscribedByData",
+                                subscribedOnData AS "subscribedOnData",
+                                promoOffers AS "promoOffers",
+                                parker_name,
+                                is_custom,
+                                updatedAt AS "updatedAt"
+                        FROM fans
+                        ORDER BY id`);
                 res.json({ fans: dbRes.rows });
         } catch (err) {
                 console.error("Error in GET /api/fans:", err);


### PR DESCRIPTION
## Summary
- expose complete fan record metadata via `/api/fans`
- document `/api/fans` response fields

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ef22abf8c8321a06abbc2af26986e