### PR TITLE
Add fan field migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ nicknames.
    Run `./setup-db.command` (macOS) or `node setup-db.js` to spin up PostgreSQL via Docker (if needed),
    create a database with a random name, and write the credentials to your `.env` file.
 
+   If you already have an existing database and are upgrading, run
+   `node migrate_add_fan_fields.js` to add any new columns that may be required.
+
 4. **Start the server**
 
    ```bash

--- a/migrate_add_fan_fields.js
+++ b/migrate_add_fan_fields.js
@@ -1,0 +1,73 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate_add_fan_fields.js
+   Purpose: Add newly required columns to the "fans" table
+   Created: 2025-08-05 – v1.0
+*/
+
+const dotenv = require('dotenv');
+dotenv.config();  // Load environment variables for db.js
+
+const pool = require('./db');
+
+// List of columns to ensure exist on the fans table
+const columns = [
+    ['username', 'TEXT'],
+    ['name', 'TEXT'],
+    ['avatar', 'TEXT'],
+    ['header', 'TEXT'],
+    ['website', 'TEXT'],
+    ['location', 'TEXT'],
+    ['gender', 'TEXT'],
+    ['birthday', 'TEXT'],
+    ['about', 'TEXT'],
+    ['notes', 'TEXT'],
+    ['lastSeen', 'TEXT'],
+    ['joined', 'TEXT'],
+    ['canReceiveChatMessage', 'BOOLEAN'],
+    ['canSendChatMessage', 'BOOLEAN'],
+    ['isBlocked', 'BOOLEAN'],
+    ['isMuted', 'BOOLEAN'],
+    ['isRestricted', 'BOOLEAN'],
+    ['isHidden', 'BOOLEAN'],
+    ['isBookmarked', 'BOOLEAN'],
+    ['isSubscribed', 'BOOLEAN'],
+    ['subscribedBy', 'TEXT'],
+    ['subscribedOn', 'TEXT'],
+    ['subscribedUntil', 'TEXT'],
+    ['renewedAd', 'BOOLEAN'],
+    ['isFriend', 'BOOLEAN'],
+    ['tipsSum', 'INTEGER'],
+    ['postsCount', 'INTEGER'],
+    ['photosCount', 'INTEGER'],
+    ['videosCount', 'INTEGER'],
+    ['audiosCount', 'INTEGER'],
+    ['mediaCount', 'INTEGER'],
+    ['subscribersCount', 'INTEGER'],
+    ['favoritesCount', 'INTEGER'],
+    ['avatarThumbs', 'JSONB'],
+    ['headerSize', 'JSONB'],
+    ['headerThumbs', 'JSONB'],
+    ['listsStates', 'JSONB'],
+    ['subscribedByData', 'JSONB'],
+    ['subscribedOnData', 'JSONB'],
+    ['promoOffers', 'JSONB'],
+    ['parker_name', 'TEXT'],
+    ['is_custom', 'BOOLEAN DEFAULT FALSE'],
+    ['updatedAt', 'TIMESTAMP NOT NULL DEFAULT NOW()']
+];
+
+(async () => {
+    try {
+        for (const [name, type] of columns) {
+            const sql = `ALTER TABLE fans ADD COLUMN IF NOT EXISTS ${name} ${type};`;
+            await pool.query(sql);
+        }
+        console.log('✅ Fan fields migration complete.');
+    } catch (err) {
+        console.error('Error running fan fields migration:', err.message);
+    } finally {
+        await pool.end();
+    }
+})();
+
+/* End of File – Last modified 2025-08-05 */

--- a/setup-db.command
+++ b/setup-db.command
@@ -17,4 +17,5 @@ fi
 
 node setup-db.js
 node migrate.js
+node migrate_add_fan_fields.js
 


### PR DESCRIPTION
## Summary
- add `migrate_add_fan_fields.js` to ensure all fan columns exist using `ALTER TABLE ... IF NOT EXISTS`
- reference new migration from `setup-db.command`
- document upgrade migration step in README

## Testing
- `node migrate_add_fan_fields.js` *(fails: Error ensuring database exists)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ef351a9488321ab4a4b71c0608b73