### PR TITLE
Ensure setup script installs db modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ nicknames.
 
    Run `./setup-db.command` (macOS) or `node setup-db.js` to spin up PostgreSQL via Docker (if needed),
    create a database with a random name, and write the credentials to your `.env` file.
+   The script verifies required Node modules such as `pg` (used for JSONB operations)
+   and `dotenv`, installing them automatically if missing.
 
    If you already have an existing database and are upgrading, run
    `node migrate_add_fan_fields.js` to add any new columns that may be required.

--- a/setup-db.command
+++ b/setup-db.command
@@ -10,7 +10,15 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-if [ ! -d node_modules/pg ]; then
+# Ensure required Node modules for database tasks are installed
+missing=false
+for mod in pg dotenv; do
+  if [ ! -d "node_modules/$mod" ]; then
+    missing=true
+    break
+  fi
+done
+if [ "$missing" = true ]; then
   echo "Installing Node dependencies..."
   npm install >/dev/null
 fi


### PR DESCRIPTION
## Summary
- ensure `setup-db.command` installs `pg` and `dotenv` when missing
- document module requirement for JSONB schema in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ef6dc91c08321b357f42e210fbd5c