### PR TITLE
docs: clarify environment and database setup

### DIFF
--- a/predeploy.html
+++ b/predeploy.html
@@ -41,16 +41,16 @@
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install.command</code> manually.</li>
       </ol>
     </li>
-    <li><strong>Add API Keys</strong>
+    <li><strong>Configure API Keys and Database (optional)</strong>
       <ol>
-        <li>Click the button below to enter your OnlyFans and OpenAI API keys. This creates your <code>.env</code> file.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='setup-env.command'">Configure API keys</button></li>
+        <li>Click the button below to enter your OnlyFans and OpenAI API keys. The script also accepts credentials for an existing PostgreSQL database; leave these fields blank to create a new database later.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='setup-env.command'">Configure API keys and DB</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>setup-env.command</code> manually.</li>
       </ol>
     </li>
     <li><strong>Create the Database</strong>
       <ol>
-        <li>Click the button below. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</li>
+        <li>If you supplied database credentials above, you can skip this step. Otherwise, click the button below to create a new database. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</li>
         <li style="margin-top:8px;"><button onclick="window.location.href='setup-db.command'">Set up new database</button></li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double‑click <code>setup-db.command</code> manually.</li>
         <li style="font-size:0.9em;color:#555;margin-top:4px;">Leave the Terminal window open until it shows “Database setup complete!”. If it reports an error, install Docker Desktop or start PostgreSQL manually and then retry. To capture detailed logs, run <code>bash setup-db.command 2>&1 | tee setup-db.log</code> and send the resulting <code>setup-db.log</code> file for support.</li>


### PR DESCRIPTION
## Summary
- Document optional database configuration alongside API keys in predeploy guide
- Note that `setup-env.command` accepts existing DB credentials and skipping database creation if supplied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9f9a5d248321a6ef1aba12e6a1c7