### PR TITLE
Handle newline markers in editor HTML

### DIFF
--- a/__tests__/getEditorHtml.test.js
+++ b/__tests__/getEditorHtml.test.js
@@ -1,0 +1,9 @@
+const getEditorHtml = require('../getEditorHtml');
+
+test('wraps content in a single paragraph', () => {
+  expect(getEditorHtml('Hello world')).toBe('<p>Hello world</p>');
+});
+
+test('converts newlines to <br>', () => {
+  expect(getEditorHtml('Line1\nLine2')).toBe('<p>Line1<br>Line2</p>');
+});

--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -68,3 +68,14 @@ test('replaces {location} placeholder', async () => {
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hi Alice! From <span>Wonderland</span></p>' });
 });
+
+test('inserts <br> for newline characters', async () => {
+  await mockPool.query("INSERT INTO fans (id, parker_name, username, location) VALUES (1, 'Alice', 'user1', 'Wonderland')");
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValueOnce({});
+  await request(app)
+    .post('/api/sendMessage')
+    .send({ userId: 1, template: 'Line1\nLine2' })
+    .expect(200);
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hi Alice! Line1<br>Line2</p>' });
+});

--- a/getEditorHtml.js
+++ b/getEditorHtml.js
@@ -1,0 +1,12 @@
+const sanitizeHtml = require('sanitize-html');
+
+function getEditorHtml(input) {
+  const sanitized = sanitizeHtml(input, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.filter(tag => tag !== 'p'),
+    allowedAttributes: sanitizeHtml.defaults.allowedAttributes
+  });
+  const withBreaks = sanitized.replace(/\r?\n/g, '<br>');
+  return `<p>${withBreaks}</p>`;
+}
+
+module.exports = getEditorHtml;

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const { Configuration, OpenAIApi } = require('openai');
 const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
-const sanitizeHtml = require('sanitize-html');
+const getEditorHtml = require('./getEditorHtml');
 dotenv.config();
 
 // Database connection pool
@@ -577,12 +577,8 @@ app.post('/api/sendMessage', async (req, res) => {
                 template = template.replace(/\{username\}/g, userName);
                 template = template.replace(/\{location\}/g, userLocation);
                 // TODO: If not already connected with this user and their profile is free, one could call a subscribe endpoint here.
-                // Sanitize and send message via OnlyFans API
-                const sanitized = sanitizeHtml(template, {
-                        allowedTags: sanitizeHtml.defaults.allowedTags.filter(tag => tag !== 'p'),
-                        allowedAttributes: sanitizeHtml.defaults.allowedAttributes
-                });
-                const formatted = `<p>${sanitized}</p>`;
+                // Sanitize, wrap, and send message via OnlyFans API
+                const formatted = getEditorHtml(template);
                 await ofApiRequest(() => ofApi.post(`/${OFAccountId}/chats/${fanId}/messages`, { text: formatted }));
                 console.log(`Sent message to ${fanId}: ${template.substring(0, 30)}...`);
 		res.json({ success: true });


### PR DESCRIPTION
## Summary
- add `getEditorHtml` helper to sanitize content, replace newlines with `<br>`, and wrap everything in one `<p>` tag
- update message sender to use `getEditorHtml`
- cover the new behaviour with unit tests

## Testing
- `npm test --silent 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688faf936214832191d850ccdbd62db2