### PR TITLE
Add placeholder insertion and preserve placeholders in sanitization

### DIFF
--- a/__tests__/editor.test.js
+++ b/__tests__/editor.test.js
@@ -1,5 +1,5 @@
 const { JSDOM } = require('jsdom');
-const { applyColor, applyBold, applySize } = require('../public/editor');
+const { applyColor, applyBold, applySize, insertPlaceholder } = require('../public/editor');
 
 function setupDom(html) {
   const dom = new JSDOM(html);
@@ -39,4 +39,17 @@ test('applySize uses OnlyFans size class', () => {
   selectElement(el);
   applySize('sm');
   expect(el.innerHTML).toBe('<span class="m-editor-fs__sm">hello</span>');
+});
+
+test('insertPlaceholder inserts text at caret', () => {
+  setupDom('<div id="msg"></div>');
+  const el = document.getElementById('msg');
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  range.collapse(true);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  insertPlaceholder('{username}');
+  expect(el.innerHTML).toBe('{username}');
 });

--- a/__tests__/getEditorHtml.test.js
+++ b/__tests__/getEditorHtml.test.js
@@ -14,6 +14,11 @@ test('allows OnlyFans span classes', () => {
 });
 
 test('strips disallowed tags and classes', () => {
-  const html = '<div class="x">Bad</div><span class="bad">Nope</span>'; 
+  const html = '<div class="x">Bad</div><span class="bad">Nope</span>';
   expect(getEditorHtml(html)).toBe('<p>Bad<span>Nope</span></p>');
+});
+
+test('preserves placeholders', () => {
+  const str = '{parker_name} {username} {location} {name} [name]';
+  expect(getEditorHtml(str)).toBe('<p>{parker_name} {username} {location} {name} [name]</p>');
 });

--- a/getEditorHtml.js
+++ b/getEditorHtml.js
@@ -10,7 +10,16 @@ const allowedSpanClasses = [
 ];
 
 function getEditorHtml(input) {
-  const sanitized = sanitizeHtml(input, {
+  const placeholders = ['{parker_name}', '{username}', '{location}', '{name}', '[name]'];
+  const tokens = [];
+  let safeInput = input;
+  placeholders.forEach((ph, i) => {
+    const token = `__OFEM_PH_${i}__`;
+    tokens.push({ token, ph });
+    safeInput = safeInput.split(ph).join(token);
+  });
+
+  let sanitized = sanitizeHtml(safeInput, {
     allowedTags: ['span', 'strong', 'em', 'br'],
     allowedAttributes: {
       span: ['class']
@@ -18,6 +27,9 @@ function getEditorHtml(input) {
     allowedClasses: {
       span: allowedSpanClasses
     }
+  });
+  tokens.forEach(({ token, ph }) => {
+    sanitized = sanitized.split(token).join(ph);
   });
   const withBreaks = sanitized.replace(/\r?\n/g, '<br>');
   return `<p>${withBreaks}</p>`;

--- a/public/editor.js
+++ b/public/editor.js
@@ -66,12 +66,26 @@
     });
   }
 
+  function insertPlaceholder(text){
+    const sel = global.getSelection ? global.getSelection() : null;
+    if(!sel || sel.rangeCount === 0) return;
+    const range = sel.getRangeAt(0);
+    range.deleteContents();
+    const node = global.document.createTextNode(text);
+    range.insertNode(node);
+    range.setStartAfter(node);
+    range.setEndAfter(node);
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+
   global.applySize = applySize;
   global.applyColor = applyColor;
   global.applyBold = applyBold;
   global.applyItalic = applyItalic;
+  global.insertPlaceholder = insertPlaceholder;
 
   if (typeof module !== 'undefined') {
-    module.exports = { applySize, applyColor, applyBold, applyItalic };
+    module.exports = { applySize, applyColor, applyBold, applyItalic, insertPlaceholder };
   }
 })(typeof window !== 'undefined' ? window : global);

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,14 @@
       </select>
       <button id="boldBtn" type="button">Bold</button>
       <button id="italicBtn" type="button">Italic</button>
+      <select id="placeholderSelect">
+        <option value="">Insert Placeholder</option>
+        <option value="{parker_name}">{parker_name}</option>
+        <option value="{username}">{username}</option>
+        <option value="{location}">{location}</option>
+        <option value="{name}">{name}</option>
+        <option value="[name]">[name]</option>
+      </select>
     </div>
     <div id="message" contenteditable="true" class="m-editor-fs__default" style="border:1px solid #ccc; padding:4px; min-height:60px;"></div>
     <button id="sendBtn">Send Personalized DM to All Fans</button>
@@ -298,6 +306,13 @@
     document.getElementById('colorSelect').addEventListener('change', e => applyColor(e.target.value));
     document.getElementById('boldBtn').addEventListener('click', applyBold);
     document.getElementById('italicBtn').addEventListener('click', applyItalic);
+    document.getElementById('placeholderSelect').addEventListener('change', e => {
+      const val = e.target.value;
+      if (val) {
+        insertPlaceholder(val);
+        e.target.value = '';
+      }
+    });
 
     // On page load, fetch any existing fans from the database
     fetchFans();


### PR DESCRIPTION
## Summary
- add placeholder dropdown to message toolbar and handler
- support inserting placeholders at caret in the editor
- keep placeholders intact during HTML sanitization and add tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdc864cdc832187014d963bf146c3