### PR TITLE
feat: support custom greeting

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -42,7 +42,7 @@ test('replaces {parker_name} placeholder', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'Hello <b>{parker_name}</b>' })
+    .send({ userId: 1, greeting: '', body: 'Hello <b>{parker_name}</b>' })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hello Alice</p>' });
 });
@@ -53,7 +53,7 @@ test('replaces {username} placeholder', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'Hey <i>{username}</i>' })
+    .send({ userId: 1, greeting: 'Hi {parker_name}!', body: 'Hey <i>{username}</i>' })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hi Alice! Hey user1</p>' });
 });
@@ -64,9 +64,9 @@ test('replaces {location} placeholder', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'From <span>{location}</span>' })
+    .send({ userId: 1, greeting: '', body: 'From <span>{location}</span>' })
     .expect(200);
-  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hi Alice! From <span>Wonderland</span></p>' });
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>From <span>Wonderland</span></p>' });
 });
 
 test('inserts <br> for newline characters', async () => {
@@ -75,9 +75,9 @@ test('inserts <br> for newline characters', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'Line1\nLine2' })
+    .send({ userId: 1, greeting: '', body: 'Line1\nLine2' })
     .expect(200);
-  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hi Alice! Line1<br>Line2</p>' });
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Line1<br>Line2</p>' });
 });
 
 test('keeps <strong> tag for bold formatting', async () => {
@@ -86,7 +86,7 @@ test('keeps <strong> tag for bold formatting', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'Hello <strong>{parker_name}</strong>' })
+    .send({ userId: 1, greeting: '', body: 'Hello <strong>{parker_name}</strong>' })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hello <strong>Alice</strong></p>' });
 });
@@ -97,7 +97,7 @@ test('retains font size class on span', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'Size <span class="m-editor-fs__l">{parker_name}</span>' })
+    .send({ userId: 1, greeting: '', body: 'Size <span class="m-editor-fs__l">{parker_name}</span>' })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Size <span class="m-editor-fs__l">Alice</span></p>' });
 });
@@ -108,7 +108,7 @@ test('retains font color class on span', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, template: 'Color <span class="m-editor-fc__blue-1">{parker_name}</span>' })
+    .send({ userId: 1, greeting: '', body: 'Color <span class="m-editor-fc__blue-1">{parker_name}</span>' })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Color <span class="m-editor-fc__blue-1">Alice</span></p>' });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     <button id="updateBtn">Update Fan Names</button>
   </p>
   <div id="messageSection" style="margin: 15px 0;">
+    <input type="text" id="greeting" value="Hi {parker_name}!" />
     <div id="toolbar">
       <select id="sizeSelect">
         <option value="default">Default</option>
@@ -218,8 +219,9 @@
         alert('No fans to send messages to.');
         return;
       }
-      const message = document.getElementById('message').innerHTML.trim();
-      if (!message) {
+      const greeting = document.getElementById('greeting').value;
+      const body = document.getElementById('message').innerHTML.trim();
+      if (!body) {
         alert('Please enter a message.');
         return;
       }
@@ -244,7 +246,7 @@
           const res = await fetch('/api/sendMessage', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId: fanId, template: message })
+            body: JSON.stringify({ userId: fanId, greeting, body })
           });
           const result = await res.json();
           if (result.success) {

--- a/server.js
+++ b/server.js
@@ -546,12 +546,14 @@ app.put('/api/fans/:id', async (req, res) => {
 
 /* Story 2: Send Personalized DM to All Fans */
 app.post('/api/sendMessage', async (req, res) => {
-	try {
+        try {
                 const fanId = req.body.userId;
-                let template = req.body.template;
-                if (!fanId || !template) {
-                        return res.status(400).send("Missing userId or template.");
+                const greeting = req.body.greeting || "";
+                const body = req.body.body || "";
+                if (!fanId || (!greeting && !body)) {
+                        return res.status(400).send("Missing userId or message.");
                 }
+                let template = [greeting, body].filter(Boolean).join(' ').trim();
 		// Ensure we have OnlyFans account ID (if updateFans not run, fetch now as fallback)
                   if (!OFAccountId) {
                           const accountsResp = await ofApiRequest(() => ofApi.get('/accounts'));
@@ -569,11 +571,7 @@ app.post('/api/sendMessage', async (req, res) => {
                 const userLocation = removeEmojis(row.location || "");
 
                 // Personalize template with placeholders
-                if (template.includes("{name}") || template.includes("[name]") || template.includes("{parker_name}")) {
-                        template = template.replace(/\{name\}|\[name\]|\{parker_name\}/g, parkerName);
-                } else {
-                        template = `Hi ${parkerName || "there"}! ${template}`;
-                }
+                template = template.replace(/\{name\}|\[name\]|\{parker_name\}/g, parkerName);
                 template = template.replace(/\{username\}/g, userName);
                 template = template.replace(/\{location\}/g, userLocation);
                 // TODO: If not already connected with this user and their profile is free, one could call a subscribe endpoint here.


### PR DESCRIPTION
## Summary
- remove automatic greeting injection and accept greeting/body separately
- add editable greeting field with default placeholder
- update tests for new sendMessage API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdd8046c8832193ee13a9ed4135e7