### PR TITLE
Add small and largest font size options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,5 +39,5 @@ Report environment, database, and external service health.
 
 - Available placeholders: `{parker_name}`, `{username}`, `{location}`, `{name}`, and `[name]`.
 - Messages are sanitized before sending. Allowed tags: `span`, `strong`, `em`, and `br`.
-- `span` tags may only use the following classes: `m-editor-fs__sm`, `m-editor-fs__l`, `m-editor-fs__default`, `m-editor-fc__gray`, `m-editor-fc__blue-1`, `m-editor-fc__blue-2`.
+- `span` tags may only use the following classes: `m-editor-fs__sm`, `m-editor-fs__s`, `m-editor-fs__default`, `m-editor-fs__l`, `m-editor-fs__lg`, `m-editor-fc__gray`, `m-editor-fc__blue-1`, `m-editor-fc__blue-2`.
 - Newline characters (`\n`) are automatically converted to `<br>`.

--- a/__tests__/editor.test.js
+++ b/__tests__/editor.test.js
@@ -41,6 +41,22 @@ test('applySize uses OnlyFans size class', () => {
   expect(el.innerHTML).toBe('<span class="m-editor-fs__sm">hello</span>');
 });
 
+test('applySize supports new size classes', () => {
+  setupDom('<div id="msg">hello</div>');
+  const el = document.getElementById('msg');
+  selectElement(el);
+  applySize('s');
+  expect(el.innerHTML).toBe('<span class="m-editor-fs__s">hello</span>');
+});
+
+test('applySize supports largest size class', () => {
+  setupDom('<div id="msg">hello</div>');
+  const el = document.getElementById('msg');
+  selectElement(el);
+  applySize('lg');
+  expect(el.innerHTML).toBe('<span class="m-editor-fs__lg">hello</span>');
+});
+
 test('insertPlaceholder inserts text at caret', () => {
   setupDom('<div id="msg"></div>');
   const el = document.getElementById('msg');

--- a/__tests__/getEditorHtml.test.js
+++ b/__tests__/getEditorHtml.test.js
@@ -13,6 +13,11 @@ test('allows OnlyFans span classes', () => {
   expect(getEditorHtml(html)).toBe('<p><span class="m-editor-fs__l m-editor-fc__blue-2">Hi</span></p>');
 });
 
+test('allows newly whitelisted size classes', () => {
+  const html = '<span class="m-editor-fs__s">Hi</span><span class="m-editor-fs__lg">Bye</span>';
+  expect(getEditorHtml(html)).toBe('<p><span class="m-editor-fs__s">Hi</span><span class="m-editor-fs__lg">Bye</span></p>');
+});
+
 test('strips disallowed tags and classes', () => {
   const html = '<div class="x">Bad</div><span class="bad">Nope</span>';
   expect(getEditorHtml(html)).toBe('<p>Bad<span>Nope</span></p>');

--- a/getEditorHtml.js
+++ b/getEditorHtml.js
@@ -2,8 +2,10 @@ const sanitizeHtml = require('sanitize-html');
 
 const allowedSpanClasses = [
   'm-editor-fs__sm',
-  'm-editor-fs__l',
+  'm-editor-fs__s',
   'm-editor-fs__default',
+  'm-editor-fs__l',
+  'm-editor-fs__lg',
   'm-editor-fc__gray',
   'm-editor-fc__blue-1',
   'm-editor-fc__blue-2'

--- a/public/editor.js
+++ b/public/editor.js
@@ -1,8 +1,10 @@
 (function(global){
   const sizeClasses = {
     sm: 'm-editor-fs__sm',
+    s: 'm-editor-fs__s',
     default: 'm-editor-fs__default',
-    l: 'm-editor-fs__l'
+    l: 'm-editor-fs__l',
+    lg: 'm-editor-fs__lg'
   };
 
   const colorClasses = {

--- a/public/index.html
+++ b/public/index.html
@@ -27,8 +27,10 @@
     <div id="toolbar">
       <select id="sizeSelect">
         <option value="default">Default</option>
-        <option value="sm">Small</option>
+        <option value="sm">Smallest</option>
+        <option value="s">Small</option>
         <option value="l">Large</option>
+        <option value="lg">Largest</option>
       </select>
       <select id="colorSelect">
         <option value="">Default</option>


### PR DESCRIPTION
## Summary
- extend editor size options to include small and largest variants
- allow new font-size classes in sanitizer and message guidelines
- test coverage for new font-size options and whitelist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fdf8335b883218ec600965eeaef18