### PR TITLE
Add vault media browsing and message options

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -113,3 +113,14 @@ test('retains font color class on span', async () => {
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Color <span class="m-editor-fc__blue-1">Alice</span></p>' });
 });
 
+test('forwards media and price fields', async () => {
+  await mockPool.query("INSERT INTO fans (id, parker_name, username, location) VALUES (1, 'Alice', 'user1', 'Wonderland')");
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValueOnce({});
+  await request(app)
+    .post('/api/sendMessage')
+    .send({ userId: 1, greeting: '', body: 'Hello', price: 5, lockedText: 'locked', mediaFiles: ['m1'], previews: ['p1'] })
+    .expect(200);
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', { text: '<p>Hello</p>', price: 5, lockedText: 'locked', mediaFiles: ['m1'], previews: ['p1'] });
+});
+

--- a/__tests__/vaultMedia.test.js
+++ b/__tests__/vaultMedia.test.js
@@ -1,0 +1,28 @@
+const mockPool = { query: jest.fn() };
+jest.mock('../db', () => mockPool);
+jest.mock('axios');
+
+const request = require('supertest');
+const mockAxios = require('axios');
+mockAxios.create.mockReturnValue(mockAxios);
+
+let app;
+beforeAll(() => {
+  process.env.ONLYFANS_API_KEY = 'test';
+  process.env.OPENAI_API_KEY = 'test';
+  app = require('../server');
+});
+
+beforeEach(() => {
+  mockAxios.get.mockReset();
+});
+
+test('GET /api/vault-media proxies to OnlyFans API', async () => {
+  mockAxios.get
+    .mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } })
+    .mockResolvedValueOnce({ data: { media: [{ id: 'm1' }] } });
+
+  const res = await request(app).get('/api/vault-media').expect(200);
+  expect(mockAxios.get).toHaveBeenCalledWith('/acc1/media/vault', { params: {} });
+  expect(res.body).toEqual({ media: [{ id: 'm1' }] });
+});

--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,14 @@
       </select>
     </div>
     <div id="message" contenteditable="true" class="m-editor-fs__default" style="border:1px solid #ccc; padding:4px; min-height:60px;"></div>
+    <div id="vaultSection" style="margin-top:10px;">
+      <button id="loadVaultBtn" type="button">Load Vault Media</button>
+      <div id="vaultMediaList" style="max-height:150px; overflow:auto; margin-top:5px;"></div>
+      <div style="margin-top:5px;">
+        <label>Price: <input type="number" id="price" min="0" step="0.01" style="width:80px;"></label>
+        <input type="text" id="lockedText" placeholder="Locked text" style="width:200px;" />
+      </div>
+    </div>
     <button id="sendBtn">Send Personalized DM to All Fans</button>
     <button id="abortBtn" disabled>Abort Sending</button>
   </div>
@@ -98,6 +106,48 @@
         renderFansTable();
       } catch (err) {
         console.error('Error fetching fans:', err);
+      }
+    }
+
+    async function loadVaultMedia() {
+      try {
+        const res = await fetch('/api/vault-media');
+        if (!res.ok) return;
+        const data = await res.json();
+        const items = Array.isArray(data) ? data : (data.list || data.results || data.media || data.data || []);
+        const container = document.getElementById('vaultMediaList');
+        container.innerHTML = '';
+        for (const m of items) {
+          const div = document.createElement('div');
+          const mediaCb = document.createElement('input');
+          mediaCb.type = 'checkbox';
+          mediaCb.className = 'mediaCheckbox';
+          mediaCb.value = m.id;
+          div.appendChild(mediaCb);
+
+          const previewCb = document.createElement('input');
+          previewCb.type = 'checkbox';
+          previewCb.className = 'previewCheckbox';
+          previewCb.value = m.id;
+          div.appendChild(previewCb);
+
+          const span = document.createElement('span');
+          span.textContent = 'Media ' + m.id;
+          div.appendChild(span);
+
+          const thumb = (m.preview && (m.preview.url || m.preview.src)) ||
+                       (m.thumb && (m.thumb.url || m.thumb.src));
+          if (thumb) {
+            const img = document.createElement('img');
+            img.src = thumb;
+            img.width = 50;
+            img.style.marginLeft = '5px';
+            div.appendChild(img);
+          }
+          container.appendChild(div);
+        }
+      } catch (err) {
+        console.error('Error loading vault media:', err);
       }
     }
 
@@ -227,6 +277,11 @@
         alert('Please enter a message.');
         return;
       }
+      const priceVal = document.getElementById('price').value;
+      const price = priceVal ? parseFloat(priceVal) : undefined;
+      const lockedText = document.getElementById('lockedText').value;
+      const mediaFiles = Array.from(document.querySelectorAll('.mediaCheckbox:checked')).map(cb => cb.value);
+      const previews = Array.from(document.querySelectorAll('.previewCheckbox:checked')).map(cb => cb.value);
       sendingInProgress = true;
       abortFlag = false;
       document.getElementById('updateBtn').disabled = true;
@@ -248,7 +303,7 @@
           const res = await fetch('/api/sendMessage', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ userId: fanId, greeting, body })
+            body: JSON.stringify({ userId: fanId, greeting, body, price, lockedText, mediaFiles, previews })
           });
           const result = await res.json();
           if (result.success) {
@@ -298,6 +353,7 @@
 
     document.getElementById('updateBtn').addEventListener('click', updateFansList);
     document.getElementById('sendBtn').addEventListener('click', sendMessagesToAll);
+    document.getElementById('loadVaultBtn').addEventListener('click', loadVaultMedia);
     document.getElementById('abortBtn').addEventListener('click', function() {
       if (sendingInProgress) {
         abortFlag = true;


### PR DESCRIPTION
## Summary
- add `/api/vault-media` route to proxy OnlyFans vault media
- allow `/api/sendMessage` to forward price, lockedText, mediaFiles and previews
- expose vault media browser and pricing inputs in dashboard UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe102c4dc8321a02a9aec9a953740