### PR TITLE
Add status reset and result download features

### DIFF
--- a/__tests__/results.test.js
+++ b/__tests__/results.test.js
@@ -1,0 +1,25 @@
+const { JSDOM } = require('jsdom');
+const { clearStatusDots, resultsToCSV, setSendResults, getSendResults } = require('../public/results');
+
+test('resultsToCSV generates CSV with header and rows', () => {
+  setSendResults([
+    { fanId: 1, username: 'user1', parkerName: 'p1', success: true },
+    { fanId: 2, username: 'user2', parkerName: 'p2', success: false, error: 'oops' }
+  ]);
+  const csv = resultsToCSV();
+  expect(csv).toBe(
+    '"fanId","username","parkerName","success","error"\n' +
+    '"1","user1","p1","success",""\n' +
+    '"2","user2","p2","fail","oops"'
+  );
+});
+
+test('clearStatusDots clears status cells and resets results', () => {
+  const dom = new JSDOM('<span id="status-1">x</span><span id="status-2">y</span>');
+  global.document = dom.window.document;
+  setSendResults([{ fanId: 1 }, { fanId: 2 }]);
+  clearStatusDots();
+  expect(dom.window.document.getElementById('status-1').innerHTML).toBe('');
+  expect(dom.window.document.getElementById('status-2').innerHTML).toBe('');
+  expect(getSendResults()).toEqual([]);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -60,6 +60,8 @@
     </div>
     <button id="sendBtn">Send Personalized DM to All Fans</button>
     <button id="abortBtn" disabled>Abort Sending</button>
+    <button id="clearStatusBtn" type="button">Clear Status</button>
+    <button id="downloadBtn" type="button">Download Results</button>
   </div>
   <div id="statusMsg" style="font-weight: bold; margin: 10px 0;"></div>
   <table id="fansTable">
@@ -78,6 +80,7 @@
   </table>
 
   <script src="editor.js"></script>
+  <script src="results.js"></script>
   <script>
     let fansData = [];
     let sendingInProgress = false;
@@ -282,6 +285,7 @@
       const lockedText = document.getElementById('lockedText').value;
       const mediaFiles = Array.from(document.querySelectorAll('.mediaCheckbox:checked')).map(cb => cb.value);
       const previews = Array.from(document.querySelectorAll('.previewCheckbox:checked')).map(cb => cb.value);
+      clearStatusDots();
       sendingInProgress = true;
       abortFlag = false;
       document.getElementById('updateBtn').disabled = true;
@@ -309,11 +313,13 @@
           if (result.success) {
             // Success: mark green
             setStatusDot(fanId, 'green');
+            addResult({ fanId, username: fan.username || '', parkerName: fan.parker_name || '', success: true });
             successCount++;
             failCount = 0;  // reset consecutive fail counter on success
           } else {
             // Failure: mark red
             setStatusDot(fanId, 'red');
+            addResult({ fanId, username: fan.username || '', parkerName: fan.parker_name || '', success: false, error: result.error || '' });
             failCount++;
             totalFailures++;
             if (failCount >= 10) {
@@ -327,6 +333,7 @@
           console.error('Error sending to fan ' + fanId + ':', err);
           // Treat network or unexpected error as failure
           setStatusDot(fanId, 'red');
+          addResult({ fanId, username: fan.username || '', parkerName: fan.parker_name || '', success: false, error: err.message });
           failCount++;
           totalFailures++;
           if (failCount >= 10) {
@@ -361,6 +368,8 @@
         this.disabled = true;
       }
     });
+    document.getElementById('clearStatusBtn').addEventListener('click', clearStatusDots);
+    document.getElementById('downloadBtn').addEventListener('click', downloadResults);
 
     document.getElementById('sizeSelect').addEventListener('change', e => applySize(e.target.value));
     document.getElementById('colorSelect').addEventListener('change', e => applyColor(e.target.value));

--- a/public/results.js
+++ b/public/results.js
@@ -1,0 +1,60 @@
+(function(global){
+  let sendResults = [];
+
+  function clearStatusDots(){
+    sendResults = [];
+    if(!global.document) return;
+    const nodes = global.document.querySelectorAll('[id^="status-"]');
+    nodes.forEach(n => { n.innerHTML = ''; });
+  }
+
+  function addResult(result){
+    sendResults.push(result);
+  }
+
+  function resultsToCSV(){
+    const header = ['fanId','username','parkerName','success','error'];
+    const rows = sendResults.map(r => [
+      r.fanId,
+      r.username || '',
+      r.parkerName || '',
+      r.success ? 'success' : 'fail',
+      r.error || ''
+    ]);
+    const all = [header, ...rows];
+    return all.map(row => row.map(val => '"' + String(val).replace(/"/g, '""') + '"').join(',')).join('\n');
+  }
+
+  function downloadResults(){
+    const csv = resultsToCSV();
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = global.document.createElement('a');
+    a.href = url;
+    a.download = 'send_results.csv';
+    global.document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function getSendResults(){
+    return sendResults;
+  }
+
+  function setSendResults(arr){
+    sendResults = Array.isArray(arr) ? arr : [];
+  }
+
+  const api = { clearStatusDots, downloadResults, addResult, resultsToCSV, getSendResults, setSendResults };
+
+  if (typeof module !== 'undefined' && module.exports){
+    module.exports = api;
+  } else {
+    global.clearStatusDots = clearStatusDots;
+    global.downloadResults = downloadResults;
+    global.addResult = addResult;
+    global.resultsToCSV = resultsToCSV;
+    global.OFEMResults = api;
+  }
+})(typeof window !== 'undefined' ? window : global);


### PR DESCRIPTION
## Summary
- add Clear Status and Download Results buttons to dashboard
- track per-fan send outcomes in memory and allow CSV downloads
- include utility module and tests for status clearing and result CSV creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe60f3fec8321bbd5f2fa72ede5d8