### PR TITLE
chore: add migration command

### DIFF
--- a/addtodatabase.command
+++ b/addtodatabase.command
@@ -1,0 +1,27 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Migration Runner
+# Usage: Double-click this file or run in Terminal to apply non-destructive migrations.
+# Created: 2025-08-05 – v1.0
+
+set -e
+cd "$(dirname "$0")"
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but not installed. Please install Node.js." >&2
+  exit 1
+fi
+
+# Ensure required Node modules for database tasks are installed
+missing=false
+for mod in pg dotenv; do
+  if [ ! -d "node_modules/$mod" ]; then
+    missing=true
+    break
+  fi
+done
+if [ "$missing" = true ]; then
+  echo "Installing Node dependencies..."
+  npm install >/dev/null
+fi
+
+node migrate_add_fan_fields.js
+node migrate_messages.js

--- a/predeploy.html
+++ b/predeploy.html
@@ -56,6 +56,13 @@
         <li style="font-size:0.9em;color:#555;margin-top:4px;">Leave the Terminal window open until it shows “Database setup complete!”. If it reports an error, install Docker Desktop or start PostgreSQL manually and then retry. To capture detailed logs, run <code>bash setup-db.command 2>&1 | tee setup-db.log</code> and send the resulting <code>setup-db.log</code> file for support.</li>
       </ol>
     </li>
+    <li><strong>Add to the Database</strong>
+      <ol>
+        <li>Run any new database migrations to update the schema without losing existing data.</li>
+        <li style="margin-top:8px;"><button onclick="window.location.href='addtodatabase.command'">Run migrations</button></li>
+        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>addtodatabase.command</code> manually.</li>
+      </ol>
+    </li>
     <li><strong>Run the App</strong>
       <ol>
         <li>Double‑click <code>start.command</code> to launch the server.</li>


### PR DESCRIPTION
## Summary
- add `addtodatabase.command` to run non-destructive migrations
- document `addtodatabase.command` in predeploy guide

## Testing
- `npm test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_688fe906bd3c8321a726b1b15ee05472