### PR TITLE
Add message history retrieval UI, API, and tests

### DIFF
--- a/__tests__/historyUI.test.js
+++ b/__tests__/historyUI.test.js
@@ -1,0 +1,33 @@
+const { JSDOM } = require('jsdom');
+
+describe('Message history UI', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('renderMessageHistory outputs messages', () => {
+    const dom = new JSDOM('<div id="messageHistory"></div>');
+    global.document = dom.window.document;
+    const { renderMessageHistory } = require('../public/history');
+    renderMessageHistory([
+      { direction: 'incoming', body: 'hi' },
+      { direction: 'outgoing', body: 'yo' }
+    ]);
+    const html = dom.window.document.getElementById('messageHistory').innerHTML;
+    expect(html).toContain('<li><strong>incoming</strong>: hi</li>');
+    expect(html).toContain('<li><strong>outgoing</strong>: yo</li>');
+  });
+
+  test('handleFetch fetches and renders history', async () => {
+    const dom = new JSDOM('<select id="fanSelect"><option value="1">F1</option></select><input id="limitInput" value="2"/><button id="fetchHistoryBtn"></button><div id="messageHistory"></div>');
+    global.document = dom.window.document;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ messages: [{ direction: 'incoming', body: 'hello' }] })
+    });
+    const { handleFetch } = require('../public/history');
+    await handleFetch();
+    expect(global.fetch).toHaveBeenCalledWith('/api/messages/history?fanId=1&limit=2');
+    expect(dom.window.document.getElementById('messageHistory').textContent).toContain('hello');
+  });
+});

--- a/__tests__/messagesHistory.test.js
+++ b/__tests__/messagesHistory.test.js
@@ -1,0 +1,63 @@
+const { newDb } = require('pg-mem');
+const mem = newDb();
+const pg = mem.adapters.createPg();
+const mockPool = new pg.Pool();
+
+jest.mock('../db', () => mockPool);
+jest.mock('axios');
+jest.mock('openai', () => ({
+  Configuration: class {},
+  OpenAIApi: jest.fn()
+}));
+
+const request = require('supertest');
+const mockAxios = require('axios');
+mockAxios.create.mockReturnValue(mockAxios);
+
+let app;
+
+beforeAll(async () => {
+  process.env.ONLYFANS_API_KEY = 'test';
+  process.env.OPENAI_API_KEY = 'test';
+  await mockPool.query(`
+    CREATE TABLE fans (
+      id BIGINT PRIMARY KEY,
+      parker_name TEXT,
+      username TEXT,
+      location TEXT
+    );
+  `);
+  await mockPool.query(`
+    CREATE TABLE messages (
+      id BIGINT PRIMARY KEY,
+      fan_id BIGINT REFERENCES fans(id),
+      direction TEXT,
+      body TEXT,
+      price NUMERIC,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+  app = require('../server');
+});
+
+beforeEach(async () => {
+  await mockPool.query('DELETE FROM messages');
+  await mockPool.query('DELETE FROM fans');
+  mockAxios.get.mockReset();
+});
+
+test('fetches and upserts message history', async () => {
+  await mockPool.query("INSERT INTO fans (id, parker_name, username, location) VALUES (1, 'Alice', 'user1', 'Wonderland')");
+  mockAxios.get
+    .mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } })
+    .mockResolvedValueOnce({ data: { messages: [{ id: 10, fromUser: { id: 'acc1' }, text: 'hi', price: 0, createdAt: 1000 }] } })
+    .mockResolvedValueOnce({ data: { messages: [{ id: 10, fromUser: { id: 'acc1' }, text: 'updated', price: 1, createdAt: 1000 }] } });
+
+  await request(app).get('/api/messages/history?fanId=1&limit=5').expect(200);
+  let rows = await mockPool.query('SELECT id, fan_id, body, price FROM messages');
+  expect(rows.rows).toEqual([{ id: 10, fan_id: 1, body: 'hi', price: 0 }]);
+
+  await request(app).get('/api/messages/history?fanId=1&limit=5').expect(200);
+  rows = await mockPool.query('SELECT id, fan_id, body, price FROM messages');
+  expect(rows.rows).toEqual([{ id: 10, fan_id: 1, body: 'updated', price: 1 }]);
+});

--- a/public/history.html
+++ b/public/history.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Message History</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    select, input { margin-right: 8px; }
+    ul { list-style: none; padding-left: 0; }
+    li { margin-bottom: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Message History</h1>
+  <div>
+    <label for="fanSelect">Fan:</label>
+    <select id="fanSelect"></select>
+    <label for="limitInput">Limit:</label>
+    <input type="number" id="limitInput" min="1" value="20" />
+    <button id="fetchHistoryBtn" type="button">Fetch</button>
+  </div>
+  <div id="messageHistory" style="margin-top:15px;"></div>
+  <script src="history.js"></script>
+  <script>
+    if (window.MessageHistory && MessageHistory.init) {
+      MessageHistory.init();
+    }
+  </script>
+</body>
+</html>

--- a/public/history.js
+++ b/public/history.js
@@ -1,0 +1,50 @@
+(function(global){
+  async function fetchFans(){
+    const res = await global.fetch('/api/fans');
+    if(!res.ok) throw new Error('Failed to fetch fans');
+    const data = await res.json();
+    return data.fans || [];
+  }
+
+  async function populateFanSelect(){
+    const fans = await fetchFans();
+    const sel = global.document.getElementById('fanSelect');
+    if(!sel) return;
+    sel.innerHTML = fans.map(f => '<option value="'+ f.id +'">'+ escapeHtml(f.username || f.name || f.parker_name || String(f.id)) +'</option>').join('');
+  }
+
+  async function fetchMessageHistory(fanId, limit){
+    const res = await global.fetch(`/api/messages/history?fanId=${fanId}&limit=${limit}`);
+    if(!res.ok) throw new Error('Failed to fetch message history');
+    const data = await res.json();
+    return data.messages || [];
+  }
+
+  function renderMessageHistory(messages){
+    const container = global.document.getElementById('messageHistory');
+    if(!container) return;
+    const items = messages.map(m => `<li><strong>${escapeHtml(m.direction || '')}</strong>: ${escapeHtml(m.body || '')}</li>`).join('');
+    container.innerHTML = `<ul>${items}</ul>`;
+  }
+
+  async function handleFetch(){
+    const fanId = global.document.getElementById('fanSelect').value;
+    const limit = global.document.getElementById('limitInput').value || 20;
+    const msgs = await fetchMessageHistory(fanId, limit);
+    renderMessageHistory(msgs);
+  }
+
+  function escapeHtml(str){
+    return String(str).replace(/[&<>"']/g, c => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[c]));
+  }
+
+  async function init(){
+    await populateFanSelect();
+    const btn = global.document.getElementById('fetchHistoryBtn');
+    if(btn) btn.addEventListener('click', handleFetch);
+  }
+
+  const api = { fetchMessageHistory, renderMessageHistory, handleFetch, populateFanSelect, init };
+  if (typeof module !== 'undefined') module.exports = api;
+  else global.MessageHistory = api;
+})(typeof window !== 'undefined' ? window : global);

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
   <h1>OnlyFans Express Messenger (OFEM)</h1>
   <p>
     <button id="updateBtn">Update Fan Names</button>
+    <a href="history.html" target="_blank">Message History</a>
   </p>
   <div id="messageSection" style="margin: 15px 0;">
     <input type="text" id="greeting" value="Hi {parker_name}!" />


### PR DESCRIPTION
## Summary
- Add link to new Message History page in dashboard
- Implement Message History page with fan picker and message limit input
- Add `GET /api/messages/history` endpoint to fetch, upsert, and return messages
- Cover endpoint and UI with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe9f15ed48321bfeb5a5253f4efdf