### PR TITLE
Ensure message migrations run and add coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ The `/api/status` endpoint reports whether each variable has been configured.
 
 ## Fan Fields Migration and New Columns
 
-Run the migration script below to ensure your database includes all of the latest fan
-profile fields.
+Run the migration scripts below to ensure your database includes all of the latest fan
+profile fields and the message-history schema.
 
 ```bash
 node migrate_add_fan_fields.js
+node migrate_messages.js
 ```
 
-The script reads connection details from your `.env` file and adds any missing columns to
-the `fans` table.  The new columns and their purposes are:
+These scripts read connection details from your `.env` file. `migrate_add_fan_fields.js`
+adds any missing columns to the `fans` table. The new columns and their purposes are:
 
 - `avatar` – URL to the fan's profile avatar
 - `header` – URL to the profile header image
@@ -124,6 +125,17 @@ the `fans` table.  The new columns and their purposes are:
 - `subscribedOnData` – JSON describing subscription timing
 - `promoOffers` – JSON describing active promotional offers
 - `updatedAt` – Timestamp of the last record update
+
+`migrate_messages.js` creates a `messages` table used for storing message history:
+
+- `id` – serial primary key
+- `fan_id` – reference to `fans.id`
+- `direction` – 'sent' or 'received'
+- `body` – message text
+- `price` – media price
+- `created_at` – timestamp when the message was created
+
+Run `./addtodatabase.command` to apply both migrations to an existing database in one step.
 
 ## Usage
 

--- a/__tests__/migrate_messages.test.js
+++ b/__tests__/migrate_messages.test.js
@@ -1,0 +1,30 @@
+const { newDb } = require('pg-mem');
+const mem = newDb();
+const pg = mem.adapters.createPg();
+const mockPool = new pg.Pool();
+const rawQuery = mockPool.query.bind(mockPool);
+mockPool.query = (text, params) => {
+  if (typeof text === 'string') text = text.replace('IF NOT EXISTS', '');
+  return rawQuery(text, params);
+};
+mockPool.end = jest.fn().mockResolvedValue();
+
+jest.mock('../db', () => mockPool);
+
+beforeAll(async () => {
+  await mockPool.query('CREATE TABLE fans(id BIGINT PRIMARY KEY);');
+  require('../migrate_messages.js');
+  await new Promise(resolve => setImmediate(resolve));
+});
+
+test('migration creates messages table with expected columns', async () => {
+  const res = await mockPool.query("SELECT column_name FROM information_schema.columns WHERE table_name='messages' ORDER BY ordinal_position");
+  expect(res.rows.map(r => r.column_name)).toEqual([
+    'id',
+    'fan_id',
+    'direction',
+    'body',
+    'price',
+    'created_at'
+  ]);
+});

--- a/setup-db.command
+++ b/setup-db.command
@@ -26,4 +26,5 @@ fi
 node setup-db.js
 node migrate.js
 node migrate_add_fan_fields.js
+node migrate_messages.js
 


### PR DESCRIPTION
## Summary
- run `migrate_messages.js` during database setup
- cover message migration with unit tests
- document message history schema and upgrade steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688feb3d0c8c8321bd853e1f0a2506d4