### PR TITLE
feat: add message scheduling

### DIFF
--- a/migrate_scheduled_messages.js
+++ b/migrate_scheduled_messages.js
@@ -1,0 +1,40 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate_scheduled_messages.js
+   Purpose: Create the "scheduled_messages" table for storing queued messages
+   Created: 2025-08-06 – v1.0
+*/
+
+const dotenv = require('dotenv');
+dotenv.config(); // Load environment variables for db.js
+
+const pool = require('./db');
+
+// SQL to create scheduled_messages table
+const createTableQuery = `
+CREATE TABLE IF NOT EXISTS scheduled_messages (
+    id SERIAL PRIMARY KEY,
+    greeting TEXT,
+    body TEXT,
+    recipients JSONB,
+    media_files JSONB,
+    previews JSONB,
+    price NUMERIC,
+    locked_text TEXT,
+    scheduled_at TIMESTAMP,
+    status TEXT DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT NOW()
+);
+`;
+
+(async () => {
+    try {
+        await pool.query(createTableQuery);
+        console.log('✅ "scheduled_messages" table has been created/updated.');
+    } catch (err) {
+        console.error('Error running scheduled_messages migration:', err.message);
+    } finally {
+        await pool.end();
+    }
+})();
+
+/* End of File – Last modified 2025-08-06 */

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
   <p>
     <button id="updateBtn">Update Fan Names</button>
     <a href="history.html" target="_blank">Message History</a>
+    <a href="queue.html" target="_blank">Scheduled Queue</a>
   </p>
   <div id="messageSection" style="margin: 15px 0;">
     <input type="text" id="greeting" value="Hi {parker_name}!" />
@@ -59,7 +60,11 @@
         <input type="text" id="lockedText" placeholder="Locked text" style="width:200px;" />
       </div>
     </div>
+    <div style="margin-top:10px;">
+      <label>Schedule Time: <input type="datetime-local" id="scheduledTime" /></label>
+    </div>
     <button id="sendBtn">Send Personalized DM to All Fans</button>
+    <button id="scheduleBtn" type="button">Schedule Message</button>
     <button id="abortBtn" disabled>Abort Sending</button>
     <button id="clearStatusBtn" type="button">Clear Status</button>
     <button id="downloadBtn" type="button">Download Results</button>
@@ -359,8 +364,47 @@
       }
     }
 
+    async function scheduleMessages() {
+      if (fansData.length === 0) {
+        alert('No fans to send messages to.');
+        return;
+      }
+      const greeting = document.getElementById('greeting').value;
+      const body = document.getElementById('message').innerHTML.trim();
+      if (!body) {
+        alert('Please enter a message.');
+        return;
+      }
+      const scheduledTime = document.getElementById('scheduledTime').value;
+      if (!scheduledTime) {
+        alert('Please choose a schedule time.');
+        return;
+      }
+      const priceVal = document.getElementById('price').value;
+      const price = priceVal ? parseFloat(priceVal) : undefined;
+      const lockedText = document.getElementById('lockedText').value;
+      const mediaFiles = Array.from(document.querySelectorAll('.mediaCheckbox:checked')).map(cb => cb.value);
+      const previews = Array.from(document.querySelectorAll('.previewCheckbox:checked')).map(cb => cb.value);
+      try {
+        const res = await fetch('/api/scheduleMessage', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ greeting, body, price, lockedText, mediaFiles, previews, recipients: fansData.map(f => f.id), scheduledTime })
+        });
+        const result = await res.json();
+        if (res.ok && result.success) {
+          alert('Message scheduled.');
+        } else {
+          alert('Error scheduling message: ' + (result.error || res.statusText));
+        }
+      } catch (err) {
+        console.error('Error scheduling message:', err);
+      }
+    }
+
     document.getElementById('updateBtn').addEventListener('click', updateFansList);
     document.getElementById('sendBtn').addEventListener('click', sendMessagesToAll);
+    document.getElementById('scheduleBtn').addEventListener('click', scheduleMessages);
     document.getElementById('loadVaultBtn').addEventListener('click', loadVaultMedia);
     document.getElementById('abortBtn').addEventListener('click', function() {
       if (sendingInProgress) {

--- a/public/queue.html
+++ b/public/queue.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Scheduled Message Queue</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    table { border-collapse: collapse; width: 100%; max-width: 800px; }
+    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
+    th { background: #f9f9f9; }
+    button { padding: 4px 8px; margin: 2px; }
+  </style>
+</head>
+<body>
+  <h1>Scheduled Message Queue</h1>
+  <table id="queueTable">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Message</th>
+        <th>Scheduled Time</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script src="queue.js"></script>
+</body>
+</html>

--- a/public/queue.js
+++ b/public/queue.js
@@ -1,0 +1,60 @@
+window.Queue = {
+  async fetch() {
+    try {
+      const res = await fetch('/api/scheduledMessages');
+      const data = await res.json();
+      this.render(data.messages || []);
+    } catch (err) {
+      console.error('Error fetching scheduled messages:', err);
+    }
+  },
+  render(messages) {
+    const tbody = document.querySelector('#queueTable tbody');
+    tbody.innerHTML = '';
+    for (const m of messages) {
+      const tr = document.createElement('tr');
+      const msgText = [m.greeting || '', m.body || ''].filter(Boolean).join(' ').trim();
+      const time = m.scheduled_at ? new Date(m.scheduled_at).toLocaleString() : '';
+      tr.innerHTML = `<td>${m.id}</td><td>${msgText}</td><td>${time}</td>`;
+      const actionsTd = document.createElement('td');
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.addEventListener('click', () => this.edit(m));
+      const cancelBtn = document.createElement('button');
+      cancelBtn.textContent = 'Cancel';
+      cancelBtn.addEventListener('click', () => this.cancel(m.id));
+      actionsTd.appendChild(editBtn);
+      actionsTd.appendChild(cancelBtn);
+      tr.appendChild(actionsTd);
+      tbody.appendChild(tr);
+    }
+  },
+  async cancel(id) {
+    try {
+      await fetch(`/api/scheduledMessages/${id}`, { method: 'DELETE' });
+      this.fetch();
+    } catch (err) {
+      console.error('Error canceling message:', err);
+    }
+  },
+  async edit(m) {
+    const combined = [m.greeting || '', m.body || ''].filter(Boolean).join(' ').trim();
+    const newBody = prompt('Edit message:', combined);
+    if (newBody === null) return;
+    const defaultTime = m.scheduled_at ? m.scheduled_at.slice(0,16) : '';
+    const newTime = prompt('New schedule time (YYYY-MM-DDTHH:MM):', defaultTime);
+    if (newTime === null) return;
+    try {
+      await fetch(`/api/scheduledMessages/${m.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: newBody, scheduledTime: newTime })
+      });
+      this.fetch();
+    } catch (err) {
+      console.error('Error editing message:', err);
+    }
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => Queue.fetch());


### PR DESCRIPTION
## Summary
- collect scheduled send times in the dashboard
- queue messages via `/api/scheduleMessage` and manage them from new endpoints
- background worker dispatches pending messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fed51cd04832192e164c5c33f74b3