### PR TITLE
style: improve predeploy guide UI

### DIFF
--- a/predeploy.html
+++ b/predeploy.html
@@ -3,77 +3,98 @@
 <head>
   <meta charset="UTF-8">
   <title>OFEM Pre‑Deploy Guide</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; line-height: 1.5; }
-    ol { max-width: 700px; }
-    button { padding: 10px 16px; font-size: 16px; cursor: pointer; }
-  </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <link rel="stylesheet" href="public/css/predeploy.css">
 </head>
 <body>
   <h1>Getting Started with OFEM</h1>
   <p>Follow these simple steps on a Mac to run OFEM. No programming knowledge required.</p>
-  <ol>
-    <li><strong>Download and Unzip</strong>
-      <ol>
-        <li>Download the project ZIP file.</li>
-        <li>Open your Downloads folder and double‑click the ZIP to create the <code>OFEM</code> folder.</li>
-      </ol>
+  <ol class="steps">
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-download step-icon"></i><strong>Download and Unzip</strong></div>
+        <ol>
+          <li>Download the project ZIP file.</li>
+          <li>Open your Downloads folder and double‑click the ZIP to create the <code>OFEM</code> folder.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Allow Scripts to Run</strong>
-      <ol>
-        <li>Click the button below to remove the quarantine flag from all <code>.command</code> files (install, setup-env, setup-db, start, etc.).</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='remove-quarantine.command'">Allow command files</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>remove-quarantine.command</code> manually.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-unlock step-icon"></i><strong>Allow Scripts to Run</strong></div>
+        <ol>
+          <li>Click the button below to remove the quarantine flag from all <code>.command</code> files (install, setup-env, setup-db, start, etc.).</li>
+          <li class="mt-sm"><button class="btn btn-primary" onclick="window.location.href='remove-quarantine.command'">Allow command files</button></li>
+          <li class="note">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>remove-quarantine.command</code> manually.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Install Requirements</strong>
-      <ol>
-        <li>Click the button below to install Node.js (LTS) in this folder and download all required npm packages.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='install-node.command'">Install Node at Folder</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-node.command</code> manually.</li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">You may be asked for your macOS password to complete the installation.</li>
-        <li>Click the button below to install Docker Desktop using Homebrew.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='install-docker.command'">Install Docker</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">This opens Terminal in the <code>OFEM</code> folder and runs <code>brew install --cask docker</code>. If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
-        <li>Once Node and Docker are installed, run the project installer below to install all Node dependencies.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='install.command'">Run installer</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install.command</code> manually.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-screwdriver-wrench step-icon"></i><strong>Install Requirements</strong></div>
+        <ol>
+          <li>Click the button below to install Node.js (LTS) in this folder and download all required npm packages.</li>
+          <li class="mt-sm"><button class="btn btn-primary" onclick="window.location.href='install-node.command'">Install Node at Folder</button></li>
+          <li class="note">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-node.command</code> manually.</li>
+          <li class="note">You may be asked for your macOS password to complete the installation.</li>
+          <li>Click the button below to install Docker Desktop using Homebrew.</li>
+          <li class="mt-sm"><button class="btn btn-secondary" onclick="window.location.href='install-docker.command'">Install Docker</button></li>
+          <li class="note">This opens Terminal in the <code>OFEM</code> folder and runs <code>brew install --cask docker</code>. If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install-docker.command</code> manually.</li>
+          <li class="note">If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</li>
+          <li>Once Node and Docker are installed, run the project installer below to install all Node dependencies.</li>
+          <li class="mt-sm"><button class="btn btn-primary" onclick="window.location.href='install.command'">Run installer</button></li>
+          <li class="note">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>install.command</code> manually.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Configure API Keys and Database (optional)</strong>
-      <ol>
-        <li>Click the button below to enter your OnlyFans and OpenAI API keys. The script also accepts credentials for an existing PostgreSQL database; leave these fields blank to create a new database later.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='setup-env.command'">Configure API keys and DB</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>setup-env.command</code> manually.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-key step-icon"></i><strong>Configure API Keys and Database (optional)</strong></div>
+        <ol>
+          <li>Click the button below to enter your OnlyFans and OpenAI API keys. The script also accepts credentials for an existing PostgreSQL database; leave these fields blank to create a new database later.</li>
+          <li class="mt-sm"><button class="btn btn-secondary" onclick="window.location.href='setup-env.command'">Configure API keys and DB</button></li>
+          <li class="note">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>setup-env.command</code> manually.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Create the Database</strong>
-      <ol>
-        <li>If you supplied database credentials above, you can skip this step. Otherwise, click the button below to create a new database. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='setup-db.command'">Set up new database</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double‑click <code>setup-db.command</code> manually.</li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">Leave the Terminal window open until it shows “Database setup complete!”. If it reports an error, install Docker Desktop or start PostgreSQL manually and then retry. To capture detailed logs, run <code>bash setup-db.command 2>&1 | tee setup-db.log</code> and send the resulting <code>setup-db.log</code> file for support.</li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">After running <code>setup-env.command</code> and <code>setup-db.command</code>, the initial database setup is complete.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-database step-icon"></i><strong>Create the Database</strong></div>
+        <ol>
+          <li>If you supplied database credentials above, you can skip this step. Otherwise, click the button below to create a new database. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</li>
+          <li class="mt-sm"><button class="btn btn-primary" onclick="window.location.href='setup-db.command'">Set up new database</button></li>
+          <li class="note">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double‑click <code>setup-db.command</code> manually.</li>
+          <li class="note">Leave the Terminal window open until it shows “Database setup complete!”. If it reports an error, install Docker Desktop or start PostgreSQL manually and then retry. To capture detailed logs, run <code>bash setup-db.command 2>&1 | tee setup-db.log</code> and send the resulting <code>setup-db.log</code> file for support.</li>
+          <li class="note">After running <code>setup-env.command</code> and <code>setup-db.command</code>, the initial database setup is complete.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Upgrade Existing Database (optional)</strong>
-      <ol>
-        <li>If you're updating an existing install, run migrations to update the schema without losing data. Fresh installations can skip this step.</li>
-        <li style="margin-top:8px;"><button onclick="window.location.href='addtodatabase.command'">Run migrations</button></li>
-        <li style="font-size:0.9em;color:#555;margin-top:4px;">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>addtodatabase.command</code> manually.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-arrow-up step-icon"></i><strong>Upgrade Existing Database (optional)</strong></div>
+        <ol>
+          <li>If you're updating an existing install, run migrations to update the schema without losing data. Fresh installations can skip this step.</li>
+          <li class="mt-sm"><button class="btn btn-secondary" onclick="window.location.href='addtodatabase.command'">Run migrations</button></li>
+          <li class="note">If the browser shows the script code instead of running it, open the <code>OFEM</code> folder in Finder and double-click <code>addtodatabase.command</code> manually.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Run the App</strong>
-      <ol>
-        <li>Double‑click <code>start.command</code> to launch the server.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-play step-icon"></i><strong>Run the App</strong></div>
+        <ol>
+          <li>Double‑click <code>start.command</code> to launch the server.</li>
+        </ol>
+      </div>
     </li>
-    <li><strong>Open the Dashboard</strong>
-      <ol>
-        <li>When Terminal shows “OFEM server listening on http://localhost:3000”, open a web browser.</li>
-        <li>Visit <a href="http://localhost:3000">http://localhost:3000</a>.</li>
-      </ol>
+    <li>
+      <div class="card">
+        <div class="card-header"><i class="fa-solid fa-display step-icon"></i><strong>Open the Dashboard</strong></div>
+        <ol>
+          <li>When Terminal shows “OFEM server listening on http://localhost:3000”, open a web browser.</li>
+          <li>Visit <a href="http://localhost:3000">http://localhost:3000</a>.</li>
+        </ol>
+      </div>
     </li>
   </ol>
   <p>The app is now ready. Use the dashboard buttons to update fan names and send messages.</p>

--- a/public/css/predeploy.css
+++ b/public/css/predeploy.css
@@ -1,0 +1,80 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap');
+:root {
+  --color-primary: #007bff;
+  --color-primary-hover: #0056b3;
+  --color-secondary: #6c757d;
+  --color-secondary-hover: #565e64;
+  --color-bg: #f9f9f9;
+  --color-text: #333;
+  --color-card-bg: #fff;
+}
+body {
+  font-family: 'Roboto', Arial, sans-serif;
+  margin: 0;
+  padding: 20px;
+  line-height: 1.6;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+.steps {
+  max-width: 800px;
+  margin: 0 auto;
+  padding-left: 1rem;
+}
+.card {
+  background: var(--color-card-bg);
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.card-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.step-icon {
+  margin-right: 0.5rem;
+  color: var(--color-primary);
+}
+.btn {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.btn-primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+.btn-primary:hover {
+  background: var(--color-primary-hover);
+}
+.btn-secondary {
+  background: var(--color-secondary);
+  color: #fff;
+}
+.btn-secondary:hover {
+  background: var(--color-secondary-hover);
+}
+.mt-sm {
+  margin-top: 0.5rem;
+}
+.note {
+  font-size: 0.9em;
+  color: #555;
+  margin-top: 0.25rem;
+}
+@media (max-width: 600px) {
+  body {
+    padding: 10px;
+  }
+  .card {
+    padding: 0.75rem;
+  }
+  .btn {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- extract predeploy styles into `public/css/predeploy.css`
- redesign predeploy steps into card-based layout with icons and button styles

## Testing
- `npm test`
- `node -e "const puppeteer=require('puppeteer');(async()=>{const b=await puppeteer.launch({args:['--no-sandbox']});const p=await b.newPage();await p.goto('file://'+process.cwd()+'/predeploy.html');console.log('Desktop title:',await p.title());await p.setViewport({width:375,height:667});await p.reload();console.log('Mobile title:',await p.title());await b.close();})()"`

------
https://chatgpt.com/codex/tasks/task_e_689001c7f76c83218bc49d0aeceec2d5