### PR TITLE
feat: add global dashboard stylesheet

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,141 @@
+:root {
+  --primary-color: #007bff;
+  --secondary-color: #6c757d;
+  --success-color: #28a745;
+  --danger-color: #dc3545;
+  --light-bg: #f9f9f9;
+  --border-color: #ccc;
+}
+
+/* Typography */
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  line-height: 1.4;
+  color: #333;
+}
+
+h1 {
+  font-size: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+/* Navigation */
+.site-header {
+  background-color: var(--primary-color);
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.nav-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.nav-bar a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.nav-bar a:hover {
+  text-decoration: underline;
+}
+
+/* Buttons */
+button {
+  padding: 6px 12px;
+  margin: 4px 2px;
+  border: 1px solid var(--border-color);
+  background-color: var(--primary-color);
+  color: #fff;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+button:disabled {
+  background-color: var(--secondary-color);
+  cursor: not-allowed;
+}
+
+/* Tables */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 800px;
+}
+
+th,
+td {
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+th {
+  background: var(--light-bg);
+}
+
+/* Inputs */
+input[type=text],
+textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+select,
+input {
+  margin-right: 8px;
+}
+
+/* Utilities */
+.mt-15 { margin-top: 15px; }
+.mt-10 { margin-top: 10px; }
+.mt-5 { margin-top: 5px; }
+.mb-8 { margin-bottom: 8px; }
+.w-80 { width: 80px; }
+.w-200 { width: 200px; }
+.scrollable { overflow: auto; }
+.font-bold { font-weight: bold; }
+.status-msg { font-weight: bold; margin: 10px 0; }
+
+/* Dot indicators */
+.dot {
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+
+.dot.green { background-color: var(--success-color); }
+.dot.red { background-color: var(--danger-color); }
+
+/* Message editor */
+.message-section { margin: 15px 0; }
+.message-editor {
+  border: 1px solid var(--border-color);
+  padding: 4px;
+  min-height: 60px;
+}
+.vault-section { margin-top: 10px; }
+.vault-media-list { max-height: 150px; overflow: auto; margin-top: 5px; }
+.schedule-section { margin-top: 10px; }
+
+/* History page */
+ul { list-style: none; padding-left: 0; }
+li { margin-bottom: 4px; }
+
+/* Status page */
+.ok { color: var(--success-color); }
+.fail { color: var(--danger-color); }
+
+/* Responsive layout */
+@media (max-width: 600px) {
+  body { margin: 10px; }
+  table { font-size: 0.9em; }
+  button { width: 100%; margin: 4px 0; }
+  .nav-bar a { display: block; margin: 5px 0; }
+  #toolbar { display: flex; flex-wrap: wrap; gap: 4px; }
+}

--- a/public/history.html
+++ b/public/history.html
@@ -3,14 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <title>Message History</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    select, input { margin-right: 8px; }
-    ul { list-style: none; padding-left: 0; }
-    li { margin-bottom: 4px; }
-  </style>
+  <link rel="stylesheet" href="css/app.css">
 </head>
 <body>
+  <header class="site-header">
+    <nav class="nav-bar">
+      <a href="index.html">Dashboard</a>
+      <a href="ppv.html">PPV Manager</a>
+      <a href="history.html">Message History</a>
+      <a href="queue.html">Scheduled Queue</a>
+    </nav>
+  </header>
   <h1>Message History</h1>
   <div>
     <label for="fanSelect">Fan:</label>
@@ -19,7 +22,7 @@
     <input type="number" id="limitInput" min="1" value="20" />
     <button id="fetchHistoryBtn" type="button">Fetch</button>
   </div>
-  <div id="messageHistory" style="margin-top:15px;"></div>
+  <div id="messageHistory" class="mt-15"></div>
   <script src="history.js"></script>
   <script>
     if (window.MessageHistory && MessageHistory.init) {

--- a/public/index.html
+++ b/public/index.html
@@ -3,29 +3,25 @@
 <head>
   <meta charset="UTF-8">
   <title>OFEM Dashboard</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    h1 { font-size: 1.5em; }
-    table { border-collapse: collapse; width: 100%; max-width: 800px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f9f9f9; }
-    input[type=text] { width: 100%; box-sizing: border-box; }
-    textarea { width: 100%; max-width: 800px; box-sizing: border-box; }
-    button { padding: 4px 8px; margin: 4px 2px; }
-    .dot { display: inline-block; height: 10px; width: 10px; border-radius: 50%; margin-right: 4px; }
-    .green { background-color: green; }
-    .red { background-color: red; }
-  </style>
+  <link rel="stylesheet" href="css/app.css">
 </head>
 <body>
+  <header class="site-header">
+    <nav class="nav-bar">
+      <a href="index.html">Dashboard</a>
+      <a href="ppv.html">PPV Manager</a>
+      <a href="history.html">Message History</a>
+      <a href="queue.html">Scheduled Queue</a>
+    </nav>
+  </header>
   <h1>OnlyFans Express Messenger (OFEM)</h1>
   <p>
     <button id="updateBtn">Update Fan Names</button>
+    <button onclick="location.href='ppv.html'">PPV Manager</button>
     <a href="history.html" target="_blank">Message History</a>
     <a href="queue.html" target="_blank">Scheduled Queue</a>
-    <button onclick="location.href='ppv.html'">PPV Manager</button>
   </p>
-  <div id="messageSection" style="margin: 15px 0;">
+  <div id="messageSection" class="message-section">
     <input type="text" id="greeting" value="Hi {parker_name}!" />
     <div id="toolbar">
       <select id="sizeSelect">
@@ -52,16 +48,16 @@
         <option value="[name]">[name]</option>
       </select>
     </div>
-    <div id="message" contenteditable="true" class="m-editor-fs__default" style="border:1px solid #ccc; padding:4px; min-height:60px;"></div>
-    <div id="vaultSection" style="margin-top:10px;">
+    <div id="message" contenteditable="true" class="m-editor-fs__default message-editor"></div>
+    <div id="vaultSection" class="vault-section">
       <button id="loadVaultBtn" type="button">Load Vault Media</button>
-      <div id="vaultMediaList" style="max-height:150px; overflow:auto; margin-top:5px;"></div>
-      <div style="margin-top:5px;">
-        <label>Price: <input type="number" id="price" min="0" step="0.01" style="width:80px;"></label>
-        <input type="text" id="lockedText" placeholder="Locked text" style="width:200px;" />
+      <div id="vaultMediaList" class="vault-media-list"></div>
+      <div class="mt-5">
+        <label>Price: <input type="number" id="price" min="0" step="0.01" class="w-80"></label>
+        <input type="text" id="lockedText" placeholder="Locked text" class="w-200" />
       </div>
     </div>
-    <div style="margin-top:10px;">
+    <div class="schedule-section">
       <label>Schedule Time: <input type="datetime-local" id="scheduledTime" /></label>
     </div>
     <button id="sendBtn">Send Personalized DM to All Fans</button>
@@ -70,7 +66,7 @@
     <button id="clearStatusBtn" type="button">Clear Status</button>
     <button id="downloadBtn" type="button">Download Results</button>
   </div>
-  <div id="statusMsg" style="font-weight: bold; margin: 10px 0;"></div>
+  <div id="statusMsg" class="status-msg"></div>
   <table id="fansTable">
     <thead>
       <tr>

--- a/public/ppv.html
+++ b/public/ppv.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <title>PPV Manager</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    h1 { font-size: 1.5em; }
-    table { border-collapse: collapse; width: 100%; max-width: 800px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f9f9f9; }
-    input[type=text], input[type=number] { width: 100%; box-sizing: border-box; }
-    button { padding: 4px 8px; margin: 4px 2px; }
-  </style>
+  <link rel="stylesheet" href="css/app.css">
 </head>
 <body>
+  <header class="site-header">
+    <nav class="nav-bar">
+      <a href="index.html">Dashboard</a>
+      <a href="ppv.html">PPV Manager</a>
+      <a href="history.html">Message History</a>
+      <a href="queue.html">Scheduled Queue</a>
+    </nav>
+  </header>
   <h1>PPV Manager</h1>
   <table>
     <thead>
@@ -26,19 +26,19 @@
     </thead>
     <tbody id="ppvTableBody"></tbody>
   </table>
-  <div style="margin-top:15px;">
-    <div style="margin-bottom:8px;">
+  <div class="mt-15">
+    <div class="mb-8">
       <label>PPV Number: <input type="number" id="ppvNumber" /></label>
     </div>
-    <div style="margin-bottom:8px;">
+    <div class="mb-8">
       <label>Description: <input type="text" id="description" /></label>
     </div>
-    <div style="margin-bottom:8px;">
-      <label>Price: <input type="number" id="price" min="0" step="0.01" /></label>
+    <div class="mb-8">
+      <label>Price: <input type="number" id="price" min="0" step="0.01" class="w-80" /></label>
     </div>
-    <div style="margin-bottom:8px;">
+    <div class="mb-8">
       <button id="loadVaultBtn" type="button">Load Vault Media</button>
-      <div id="vaultMediaList" style="max-height:150px; overflow:auto; margin-top:5px;"></div>
+      <div id="vaultMediaList" class="vault-media-list"></div>
     </div>
     <button id="saveBtn" type="button">Save PPV</button>
   </div>

--- a/public/queue.html
+++ b/public/queue.html
@@ -3,15 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <title>Scheduled Message Queue</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    table { border-collapse: collapse; width: 100%; max-width: 800px; }
-    th, td { border: 1px solid #ccc; padding: 6px 8px; text-align: left; }
-    th { background: #f9f9f9; }
-    button { padding: 4px 8px; margin: 2px; }
-  </style>
+  <link rel="stylesheet" href="css/app.css">
 </head>
 <body>
+  <header class="site-header">
+    <nav class="nav-bar">
+      <a href="index.html">Dashboard</a>
+      <a href="ppv.html">PPV Manager</a>
+      <a href="history.html">Message History</a>
+      <a href="queue.html">Scheduled Queue</a>
+    </nav>
+  </header>
   <h1>Scheduled Message Queue</h1>
   <table id="queueTable">
     <thead>

--- a/public/test.html
+++ b/public/test.html
@@ -3,17 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <title>OFEM System Status</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    .ok { color: green; }
-    .fail { color: red; }
-    table { border-collapse: collapse; margin-top: 10px; }
-    th, td { border: 1px solid #ccc; padding: 6px 10px; }
-  </style>
+  <link rel="stylesheet" href="css/app.css">
 </head>
 <body>
+  <header class="site-header">
+    <nav class="nav-bar">
+      <a href="index.html">Dashboard</a>
+      <a href="ppv.html">PPV Manager</a>
+      <a href="history.html">Message History</a>
+      <a href="queue.html">Scheduled Queue</a>
+    </nav>
+  </header>
   <h1>System Status</h1>
-  <table id="statusTable">
+  <table id="statusTable" class="mt-10">
     <thead><tr><th>Component</th><th>Status</th><th>Details</th></tr></thead>
     <tbody></tbody>
   </table>


### PR DESCRIPTION
## Summary
- add shared `public/css/app.css` for typography, colors, buttons, tables, and responsive tweaks
- clean up dashboard HTML to link the stylesheet, drop inline styles, and add a shared navigation header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689003ff11908321ba3dff2657cc0aaa