### PR TITLE
refactor: add reusable form styles

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -44,44 +44,85 @@ h1 {
 }
 
 /* Buttons */
-button {
+.btn {
   padding: 6px 12px;
   margin: 4px 2px;
   border: 1px solid var(--border-color);
-  background-color: var(--primary-color);
-  color: #fff;
-  cursor: pointer;
   border-radius: 4px;
+  cursor: pointer;
+  background-color: var(--light-bg);
+  color: #333;
+  text-decoration: none;
 }
 
-button:disabled {
+.btn:hover,
+.btn:focus {
+  background-color: #e2e6ea;
+}
+
+.btn:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background-color: #0056b3;
+}
+
+.btn-secondary {
+  background-color: var(--secondary-color);
+  color: #fff;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background-color: #5a6268;
+}
+
+.btn:disabled,
+.btn.disabled {
   background-color: var(--secondary-color);
   cursor: not-allowed;
+  opacity: 0.65;
 }
 
 /* Tables */
-table {
+.form-table {
   border-collapse: collapse;
   width: 100%;
   max-width: 800px;
 }
 
-th,
-td {
+.form-table th,
+.form-table td {
   border: 1px solid var(--border-color);
   padding: 6px 8px;
   text-align: left;
 }
 
-th {
+.form-table th {
   background: var(--light-bg);
 }
 
 /* Inputs */
-input[type=text],
-textarea {
+.form-input {
   width: 100%;
+  padding: 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
   box-sizing: border-box;
+}
+
+.form-input:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+  outline: none;
 }
 
 select,

--- a/public/history.html
+++ b/public/history.html
@@ -17,10 +17,10 @@
   <h1>Message History</h1>
   <div>
     <label for="fanSelect">Fan:</label>
-    <select id="fanSelect"></select>
+    <select id="fanSelect" class="form-input"></select>
     <label for="limitInput">Limit:</label>
-    <input type="number" id="limitInput" min="1" value="20" />
-    <button id="fetchHistoryBtn" type="button">Fetch</button>
+    <input type="number" id="limitInput" min="1" value="20" class="form-input w-80" />
+    <button id="fetchHistoryBtn" type="button" class="btn btn-primary">Fetch</button>
   </div>
   <div id="messageHistory" class="mt-15"></div>
   <script src="history.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -16,30 +16,30 @@
   </header>
   <h1>OnlyFans Express Messenger (OFEM)</h1>
   <p>
-    <button id="updateBtn">Update Fan Names</button>
-    <button onclick="location.href='ppv.html'">PPV Manager</button>
+    <button id="updateBtn" class="btn btn-primary">Update Fan Names</button>
+    <button class="btn btn-primary" onclick="location.href='ppv.html'">PPV Manager</button>
     <a href="history.html" target="_blank">Message History</a>
     <a href="queue.html" target="_blank">Scheduled Queue</a>
   </p>
   <div id="messageSection" class="message-section">
-    <input type="text" id="greeting" value="Hi {parker_name}!" />
+    <input type="text" id="greeting" class="form-input" value="Hi {parker_name}!" />
     <div id="toolbar">
-      <select id="sizeSelect">
+      <select id="sizeSelect" class="form-input">
         <option value="default">Default</option>
         <option value="sm">Smallest</option>
         <option value="s">Small</option>
         <option value="l">Large</option>
         <option value="lg">Largest</option>
       </select>
-      <select id="colorSelect">
+      <select id="colorSelect" class="form-input">
         <option value="">Default</option>
         <option value="gray">Gray</option>
         <option value="blue1">Blue 1</option>
         <option value="blue2">Blue 2</option>
       </select>
-      <button id="boldBtn" type="button">Bold</button>
-      <button id="italicBtn" type="button">Italic</button>
-      <select id="placeholderSelect">
+      <button id="boldBtn" type="button" class="btn btn-secondary">Bold</button>
+      <button id="italicBtn" type="button" class="btn btn-secondary">Italic</button>
+      <select id="placeholderSelect" class="form-input">
         <option value="">Insert Placeholder</option>
         <option value="{parker_name}">{parker_name}</option>
         <option value="{username}">{username}</option>
@@ -50,24 +50,24 @@
     </div>
     <div id="message" contenteditable="true" class="m-editor-fs__default message-editor"></div>
     <div id="vaultSection" class="vault-section">
-      <button id="loadVaultBtn" type="button">Load Vault Media</button>
+      <button id="loadVaultBtn" type="button" class="btn btn-primary">Load Vault Media</button>
       <div id="vaultMediaList" class="vault-media-list"></div>
       <div class="mt-5">
-        <label>Price: <input type="number" id="price" min="0" step="0.01" class="w-80"></label>
-        <input type="text" id="lockedText" placeholder="Locked text" class="w-200" />
+        <label>Price: <input type="number" id="price" min="0" step="0.01" class="form-input w-80"></label>
+        <input type="text" id="lockedText" placeholder="Locked text" class="form-input w-200" />
       </div>
     </div>
     <div class="schedule-section">
-      <label>Schedule Time: <input type="datetime-local" id="scheduledTime" /></label>
+      <label>Schedule Time: <input type="datetime-local" id="scheduledTime" class="form-input" /></label>
     </div>
-    <button id="sendBtn">Send Personalized DM to All Fans</button>
-    <button id="scheduleBtn" type="button">Schedule Message</button>
-    <button id="abortBtn" disabled>Abort Sending</button>
-    <button id="clearStatusBtn" type="button">Clear Status</button>
-    <button id="downloadBtn" type="button">Download Results</button>
+    <button id="sendBtn" class="btn btn-primary">Send Personalized DM to All Fans</button>
+    <button id="scheduleBtn" type="button" class="btn btn-primary">Schedule Message</button>
+    <button id="abortBtn" class="btn btn-secondary" disabled>Abort Sending</button>
+    <button id="clearStatusBtn" type="button" class="btn btn-secondary">Clear Status</button>
+    <button id="downloadBtn" type="button" class="btn btn-secondary">Download Results</button>
   </div>
   <div id="statusMsg" class="status-msg"></div>
-  <table id="fansTable">
+  <table id="fansTable" class="form-table">
     <thead>
       <tr>
         <th>Username</th>
@@ -182,6 +182,7 @@
         input.type = 'text';
         input.id = `name-${id}`;
         input.value = parkerName;
+        input.className = 'form-input';
         tdParker.appendChild(input);
         tr.appendChild(tdParker);
 
@@ -194,6 +195,7 @@
         const tdSave = document.createElement('td');
         const btn = document.createElement('button');
         btn.textContent = 'Save';
+        btn.className = 'btn btn-secondary';
         btn.addEventListener('click', () => updateName(String(id)));
         tdSave.appendChild(btn);
         tr.appendChild(tdSave);

--- a/public/ppv.html
+++ b/public/ppv.html
@@ -15,7 +15,7 @@
     </nav>
   </header>
   <h1>PPV Manager</h1>
-  <table>
+  <table class="form-table">
     <thead>
       <tr>
         <th>PPV #</th>
@@ -28,19 +28,19 @@
   </table>
   <div class="mt-15">
     <div class="mb-8">
-      <label>PPV Number: <input type="number" id="ppvNumber" /></label>
+      <label>PPV Number: <input type="number" id="ppvNumber" class="form-input" /></label>
     </div>
     <div class="mb-8">
-      <label>Description: <input type="text" id="description" /></label>
+      <label>Description: <input type="text" id="description" class="form-input" /></label>
     </div>
     <div class="mb-8">
-      <label>Price: <input type="number" id="price" min="0" step="0.01" class="w-80" /></label>
+      <label>Price: <input type="number" id="price" min="0" step="0.01" class="form-input w-80" /></label>
     </div>
     <div class="mb-8">
-      <button id="loadVaultBtn" type="button">Load Vault Media</button>
+      <button id="loadVaultBtn" type="button" class="btn btn-primary">Load Vault Media</button>
       <div id="vaultMediaList" class="vault-media-list"></div>
     </div>
-    <button id="saveBtn" type="button">Save PPV</button>
+    <button id="saveBtn" type="button" class="btn btn-primary">Save PPV</button>
   </div>
   <script>
     async function fetchPpvs() {
@@ -59,7 +59,7 @@
       tbody.innerHTML = '';
       for (const p of ppvs) {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.description}</td><td>${p.price}</td><td><button onclick="deletePpv(${p.id})">Delete</button></td>`;
+        tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.description}</td><td>${p.price}</td><td><button class="btn btn-secondary" onclick="deletePpv(${p.id})">Delete</button></td>`;
         tbody.appendChild(tr);
       }
     }

--- a/public/queue.html
+++ b/public/queue.html
@@ -15,7 +15,7 @@
     </nav>
   </header>
   <h1>Scheduled Message Queue</h1>
-  <table id="queueTable">
+  <table id="queueTable" class="form-table">
     <thead>
       <tr>
         <th>ID</th>

--- a/public/queue.js
+++ b/public/queue.js
@@ -19,9 +19,11 @@ window.Queue = {
       const actionsTd = document.createElement('td');
       const editBtn = document.createElement('button');
       editBtn.textContent = 'Edit';
+      editBtn.className = 'btn btn-secondary';
       editBtn.addEventListener('click', () => this.edit(m));
       const cancelBtn = document.createElement('button');
       cancelBtn.textContent = 'Cancel';
+      cancelBtn.className = 'btn btn-secondary';
       cancelBtn.addEventListener('click', () => this.cancel(m.id));
       actionsTd.appendChild(editBtn);
       actionsTd.appendChild(cancelBtn);

--- a/public/test.html
+++ b/public/test.html
@@ -15,7 +15,7 @@
     </nav>
   </header>
   <h1>System Status</h1>
-  <table id="statusTable" class="mt-10">
+  <table id="statusTable" class="form-table mt-10">
     <thead><tr><th>Component</th><th>Status</th><th>Details</th></tr></thead>
     <tbody></tbody>
   </table>


### PR DESCRIPTION
## Summary
- add reusable `.btn`, `.btn-primary`, `.btn-secondary`, `.form-input`, and `.form-table` classes with hover/focus states
- refactor HTML and scripts to use new button and input classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900676499483219550c5fb444af665