### PR TITLE
Validate environment config before sending messages

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -19,6 +19,9 @@ let app;
 beforeAll(async () => {
   process.env.ONLYFANS_API_KEY = 'test';
   process.env.OPENAI_API_KEY = 'test';
+  process.env.DB_NAME = 'testdb';
+  process.env.DB_USER = 'user';
+  process.env.DB_PASSWORD = 'pass';
   await mockPool.query(`
     CREATE TABLE fans (
       id BIGINT PRIMARY KEY,
@@ -45,6 +48,16 @@ beforeEach(async () => {
   await mockPool.query('DELETE FROM fans');
   mockAxios.get.mockReset();
   mockAxios.post.mockReset();
+});
+
+test('returns 400 when required env vars are missing', async () => {
+  delete process.env.ONLYFANS_API_KEY;
+  const res = await request(app)
+    .post('/api/sendMessage')
+    .send({ userId: 1, body: 'Hi' });
+  expect(res.status).toBe(400);
+  expect(res.body).toEqual({ error: expect.stringContaining('ONLYFANS_API_KEY') });
+  process.env.ONLYFANS_API_KEY = 'test';
 });
 
 test('replaces {parker_name} placeholder', async () => {


### PR DESCRIPTION
## Summary
- verify required OnlyFans, database, and OpenAI environment variables before sending messages
- log and abort scheduled message processing if configuration is missing
- add tests for missing environment variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900ccb7f748321a592df467057ff4d