### PR TITLE
docs: clarify configurable server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,14 @@ The `/api/status` endpoint reports whether each variable has been configured.
    npm start
    ```
 
-   The server listens on <http://localhost:3000> by default.  A convenience script
+   The server listens on <http://localhost:3000> by default. To use a different port,
+   set the `PORT` environment variable before starting, for example:
+
+   ```bash
+   PORT=8080 npm start
+   ```
+
+   You can also define `PORT` in your `.env` file. A convenience script
    `start.command` (macOS) installs npm packages if required and then launches the server.
 
 ## Fan Fields Migration and New Columns

--- a/predeploy.html
+++ b/predeploy.html
@@ -91,8 +91,8 @@
       <div class="card">
         <div class="card-header"><i class="fa-solid fa-display step-icon"></i><strong>Open the Dashboard</strong></div>
         <ol>
-          <li>When Terminal shows “OFEM server listening on http://localhost:3000”, open a web browser.</li>
-          <li>Visit <a href="http://localhost:3000">http://localhost:3000</a>.</li>
+          <li>When Terminal shows “OFEM server listening on http://localhost:3000” (or another port), open a web browser. If port 3000 is in use, edit your <code>.env</code> file and change the <code>PORT</code> value, then restart <code>start.command</code>.</li>
+          <li>Visit <a href="http://localhost:3000">http://localhost:3000</a> (replace <code>3000</code> with your chosen port).</li>
         </ol>
       </div>
     </li>


### PR DESCRIPTION
## Summary
- explain how to override the default 3000 port in README with `PORT` examples and `.env` note
- update predeploy instructions to handle custom dashboard ports and editing `.env`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890126ff5a483219d32baee96b02327