### PR TITLE
feat: improve node installer

### DIFF
--- a/install-node.command
+++ b/install-node.command
@@ -4,20 +4,27 @@
 set -e
 cd "$(dirname "$0")"
 
-NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/index.json |
-  python3 -c "import sys, json; print(next(r['version'] for r in json.load(sys.stdin) if r.get('lts')))" )
-NODE_PKG="node-${NODE_VERSION}.pkg"
-NODE_URL="https://nodejs.org/dist/${NODE_VERSION}/${NODE_PKG}"
+# Discover latest LTS Node.js version using POSIX tools.
+NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/index.tab 2>/dev/null |
+  awk 'NR>1 && $10 != "-" {print $1; exit}')
 
-echo "📦 Downloading Node.js ${NODE_VERSION} (LTS)..."
-curl -fsSL "$NODE_URL" -o "$NODE_PKG"
+if [ -n "$NODE_VERSION" ]; then
+  NODE_PKG="node-${NODE_VERSION}.pkg"
+  NODE_URL="https://nodejs.org/dist/${NODE_VERSION}/${NODE_PKG}"
 
-echo "⚙️ Installing Node.js..."
-if command -v installer >/dev/null 2>&1; then
-  sudo installer -pkg "$NODE_PKG" -target /
-  rm "$NODE_PKG"
+  echo "📦 Downloading Node.js ${NODE_VERSION} (LTS)..."
+  curl -fsSL "$NODE_URL" -o "$NODE_PKG"
+
+  echo "⚙️ Installing Node.js..."
+  if command -v installer >/dev/null 2>&1; then
+    sudo installer -pkg "$NODE_PKG" -target /
+    rm "$NODE_PKG"
+  else
+    echo "installer command not found; skipping Node.js installation"
+  fi
 else
-  echo "installer command not found; skipping Node.js installation"
+  echo "⚠️ Unable to reach nodejs.org. Skipping Node.js download."
+  echo "   Please manually download the LTS version from https://nodejs.org/."
 fi
 
 echo "📚 Installing npm packages..."


### PR DESCRIPTION
## Summary
- remove Python usage in the node installer and use curl+awk to find latest LTS
- skip node download when offline and show manual download instructions

## Testing
- `npm test`
- `./install-node.command`

------
https://chatgpt.com/codex/tasks/task_e_6890133b5db48321af619c6fb82df3e8