### PR TITLE
feat: pin node version

### DIFF
--- a/install-node.command
+++ b/install-node.command
@@ -1,30 +1,33 @@
 #!/bin/bash
 # OnlyFans Express Messenger (OFEM) - Node.js Install Script
-# Downloads the latest LTS version of Node.js and installs project dependencies.
+# Downloads a specific LTS version of Node.js and installs project dependencies.
 set -e
 cd "$(dirname "$0")"
 
-# Discover latest LTS Node.js version using POSIX tools.
-NODE_VERSION=$(curl -fsSL https://nodejs.org/dist/index.tab 2>/dev/null |
-  awk 'NR>1 && $10 != "-" {print $1; exit}')
+# Update NODE_VERSION when upgrading Node.js.
+# See https://nodejs.org/en/about/releases/ for latest LTS releases.
+NODE_VERSION="v22.18.0"
 
-if [ -n "$NODE_VERSION" ]; then
+# Skip installation if desired version is already installed.
+if command -v node >/dev/null 2>&1 && [ "$(node -v)" = "$NODE_VERSION" ]; then
+  echo "✅ Node.js $NODE_VERSION already installed; skipping download."
+else
   NODE_PKG="node-${NODE_VERSION}.pkg"
   NODE_URL="https://nodejs.org/dist/${NODE_VERSION}/${NODE_PKG}"
 
   echo "📦 Downloading Node.js ${NODE_VERSION} (LTS)..."
-  curl -fsSL "$NODE_URL" -o "$NODE_PKG"
-
-  echo "⚙️ Installing Node.js..."
-  if command -v installer >/dev/null 2>&1; then
-    sudo installer -pkg "$NODE_PKG" -target /
-    rm "$NODE_PKG"
+  if curl -fsSL "$NODE_URL" -o "$NODE_PKG"; then
+    echo "⚙️ Installing Node.js..."
+    if command -v installer >/dev/null 2>&1; then
+      sudo installer -pkg "$NODE_PKG" -target /
+      rm "$NODE_PKG"
+    else
+      echo "installer command not found; skipping Node.js installation"
+    fi
   else
-    echo "installer command not found; skipping Node.js installation"
+    echo "⚠️ Unable to download Node.js ${NODE_VERSION}."
+    echo "   Please manually download the LTS version from https://nodejs.org/."
   fi
-else
-  echo "⚠️ Unable to reach nodejs.org. Skipping Node.js download."
-  echo "   Please manually download the LTS version from https://nodejs.org/."
 fi
 
 echo "📚 Installing npm packages..."


### PR DESCRIPTION
## Summary
- pin install-node.command to Node.js LTS v22.18.0
- skip Node.js installation when correct version already installed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689027a63230832193bc8ff32f3352e7