### PR TITLE
chore: update Node.js to 22 LTS

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ nicknames.
 
 ## Prerequisites
 
-- Node.js 14+
+- Node.js 22 LTS (v22.18.0)
 - PostgreSQL database accessible via `DATABASE_URL`
 - OnlyFans API key
 - OpenAI API key

--- a/install-node.command
+++ b/install-node.command
@@ -6,6 +6,7 @@ cd "$(dirname "$0")"
 
 # Update NODE_VERSION when upgrading Node.js.
 # See https://nodejs.org/en/about/releases/ for latest LTS releases.
+# Currently targeting Node.js 22 LTS (Jod).
 NODE_VERSION="v22.18.0"
 NODE_MAJOR="${NODE_VERSION#v}"
 NODE_MAJOR="${NODE_MAJOR%%.*}"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "pg-mem": "^2.1.1",
     "supertest": "^7.1.3"
   },
+  "engines": {
+    "node": ">=22.18.0"
+  },
   "jest": {
     "testEnvironment": "node"
   }


### PR DESCRIPTION
## Summary
- document Node.js 22 LTS requirement
- run CI on Node.js 22 only
- enforce Node.js 22 through install script and package engines

## Testing
- `/usr/bin/npm test`


------
https://chatgpt.com/codex/tasks/task_e_68902cc7b48c8321908bffcdd6b719d0