### PR TITLE
Retry brew link on Node install

### DIFF
--- a/install-node.command
+++ b/install-node.command
@@ -20,7 +20,9 @@ else
     if ! brew ls --versions "node@${NODE_MAJOR}" >/dev/null 2>&1; then
       brew install "node@${NODE_MAJOR}"
     fi
-    brew link "node@${NODE_MAJOR}"
+    if ! brew link "node@${NODE_MAJOR}"; then
+      brew link --overwrite --force "node@${NODE_MAJOR}"
+    fi
   else
     NODE_PKG="node-${NODE_VERSION}.pkg"
     NODE_URL="https://nodejs.org/dist/${NODE_VERSION}/${NODE_PKG}"


### PR DESCRIPTION
## Summary
- Improve Homebrew Node install script to retry `brew link` with `--overwrite --force`

## Testing
- `./install-node.command`
- `node -v`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890328be72c8321bf4473c9974d8277