### PR TITLE
Merge fan and following lists

### DIFF
--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -100,6 +100,7 @@ test('inserts and retrieves fan with new columns', async () => {
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } })
+    .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
   await request(app).post('/api/updateFans').expect(200);
@@ -152,11 +153,13 @@ test('updates existing fan fields', async () => {
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData1] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } })
+    .mockResolvedValueOnce({ data: { data: { list: [fanData1] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } })
     // second call for update
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData2] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } })
+    .mockResolvedValueOnce({ data: { data: { list: [fanData2] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
   await request(app).post('/api/updateFans').expect(200); // insert


### PR DESCRIPTION
## Summary
- combine OnlyFans fan and following lookups into a single deduped list
- update tests to cover new `fans/all` and `following/all` endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689038afb8b08321b6a3baffe0abca76