### PR TITLE
Handle followings in updateFans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 ## API Endpoints
 
 ### `POST /api/updateFans`
-Fetch OnlyFans subscribers, generate Parker names, and upsert them in the database.
+Fetch OnlyFans subscribers and followings, generate Parker names, and upsert them in the database.
 - **Request Body:** none (requires `ONLYFANS_API_KEY` and `OPENAI_API_KEY` env vars).
 - **Response:** `200` with `{"fans":[{"id":number,"username":string,"name":string,"parker_name":string}]}`.
   Returns `400` with `{ "error": string }` if prerequisites are missing.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ nicknames.
 
 ## Features
 
-- **Update Fan Names** – Fetches all fans and assigns each a short “Parker name” using
-  GPT‑4 according to the rules in the project plan.  Names can be edited and saved.
+- **Update Fan Names** – Fetches all subscribers and followings and assigns each a short
+  “Parker name” using GPT‑4 according to the rules in the project plan.  Names can be
+  edited and saved.
 - **Send Personalised DM** – Sends a message to every fan, greeting each with their
   Parker name.  Shows a green dot for success and red for failure.  Sending can be
   aborted and auto‑stops after ten consecutive errors.
@@ -147,7 +148,7 @@ Run `./addtodatabase.command` to apply both migrations to an existing database i
 ## Usage
 
 1. Open a browser to <http://localhost:3000>.
-2. Click **Update Fan Names** to load fans and generate Parker names.
+2. Click **Update Fan Names** to load subscribers and followings and generate Parker names.
 3. Edit any names and click **Save** beside a fan to persist the change.
 4. Type the message to broadcast.  Use `{name}` or `[name]` as a placeholder or leave
    it out to have the greeting prefixed automatically.

--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -177,3 +177,28 @@ test('updates existing fan fields', async () => {
     parker_name: 'Alice'
   });
 });
+
+test('upserts followings with Parker names', async () => {
+  const fanData = { id: 1, username: 'user1', name: 'Profile One' };
+  const followingData = { id: 2, username: 'user2', name: 'Profile Two' };
+
+  mockAxios.post
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
+
+  mockAxios.get
+    .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
+    .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
+    .mockResolvedValueOnce({ data: { data: { list: [] } } })
+    .mockResolvedValueOnce({ data: { data: { list: [followingData] } } })
+    .mockResolvedValueOnce({ data: { data: { list: [] } } });
+
+  await request(app).post('/api/updateFans').expect(200);
+
+  const res = await request(app).get('/api/fans').expect(200);
+  expect(res.body.fans).toHaveLength(2);
+  const fan = res.body.fans.find(f => f.id === 1);
+  const following = res.body.fans.find(f => f.id === 2);
+  expect(fan.parker_name).toBe('Alice');
+  expect(following.parker_name).toBe('Bob');
+});

--- a/server.js
+++ b/server.js
@@ -248,10 +248,13 @@ app.post('/api/updateFans', async (req, res) => {
                 };
                 const fansList = await fetchPaged(`/${OFAccountId}/fans/all`);
                 const followingList = await fetchPaged(`/${OFAccountId}/following/all`);
+                // Merge fans and followings, ensuring each OnlyFans user is processed once
                 const fanMap = new Map();
-                [...fansList, ...followingList].forEach(f => { fanMap.set(f.id, f); });
+                [...fansList, ...followingList].forEach(user => {
+                        fanMap.set(user.id, user);
+                });
                 const allFans = Array.from(fanMap.values());
-                console.log(`Fetched ${allFans.length} fans from OnlyFans.`);
+                console.log(`Fetched ${allFans.length} unique fans and followings from OnlyFans.`);
 		
 		// 3. Load existing fans from DB
 		const dbRes = await pool.query('SELECT id, parker_name, is_custom FROM fans');


### PR DESCRIPTION
## Summary
- Merge OnlyFans subscribers and followings, then upsert each with Parker name generation
- Document that `POST /api/updateFans` now processes subscribers and followings
- Add regression test covering following insertion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689039c546b88321a7255fec6f253532