### PR TITLE
Split fan list refresh from Parker name generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,15 @@
 
 ## API Endpoints
 
-### `POST /api/updateFans`
-Fetch OnlyFans subscribers and followings, generate Parker names, and upsert them in the database.
-- **Request Body:** none (requires `ONLYFANS_API_KEY` and `OPENAI_API_KEY` env vars).
-- **Response:** `200` with `{"fans":[{"id":number,"username":string,"name":string,"parker_name":string}]}`.
-  Returns `400` with `{ "error": string }` if prerequisites are missing.
+### `POST /api/refreshFans`
+Fetch OnlyFans subscribers and followings and upsert them in the database without GPT.
+- **Request Body:** none (requires `ONLYFANS_API_KEY`).
+- **Response:** `200` with `{ "fans": [{...}] }`.
+
+### `POST /api/updateParkerNames`
+Generate Parker names for stored fans missing `parker_name` using GPT‑4.
+- **Request Body:** none (requires `OPENAI_API_KEY`).
+- **Response:** `200` with `{ "fans": [{...}] }`.
 
 ### `POST /api/sendMessage`
 Send a personalized message to a fan.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ nicknames.
 
 ## Features
 
-- **Update Fan Names** – Fetches all subscribers and followings and assigns each a short
-  “Parker name” using GPT‑4 according to the rules in the project plan.  Names can be
-  edited and saved.
+- **Update Fan List** – Fetches all subscribers and followings and stores them in the
+  database without calling GPT.
+- **Update Parker Names** – Generates a short “Parker name” with GPT‑4 only for fans who
+  do not already have one. Names can be edited and saved.
 - **Send Personalised DM** – Sends a message to every fan, greeting each with their
   Parker name.  Shows a green dot for success and red for failure.  Sending can be
   aborted and auto‑stops after ten consecutive errors.
@@ -45,7 +46,8 @@ nicknames.
 The server reads the following variables from your environment or `.env` file:
 
 - `ONLYFANS_API_KEY` – authenticates requests to the OnlyFans API.
-- `OPENAI_API_KEY` – enables OpenAI GPT‑4 for generating Parker names.
+- `OPENAI_API_KEY` – enables OpenAI GPT‑4 for generating Parker names (required only
+  for `/api/updateParkerNames`).
 - `DB_NAME` – name of the PostgreSQL database to use.
 - `DB_USER` – PostgreSQL username.
 - `DB_PASSWORD` – password for the database user.
@@ -149,14 +151,25 @@ Run `./addtodatabase.command` to apply both migrations to an existing database i
 ## Usage
 
 1. Open a browser to <http://localhost:3000>.
-2. Click **Update Fan Names** to load subscribers and followings and generate Parker names.
-3. Edit any names and click **Save** beside a fan to persist the change.
-4. Type the message to broadcast.  Use `{name}` or `[name]` as a placeholder or leave
+2. Click **Update Fan List** to load subscribers and followings into the table.
+3. Click **Update Parker Names** to generate missing Parker names with GPT‑4.
+4. Edit any names and click **Save** beside a fan to persist the change.
+5. Type the message to broadcast.  Use `{name}` or `[name]` as a placeholder or leave
    it out to have the greeting prefixed automatically.
-5. Click **Send Personalised DM to All Fans** to start sending.  Use **Abort Sending**
+6. Click **Send Personalised DM to All Fans** to start sending.  Use **Abort Sending**
    to stop early.
 
 ## API
+
+### `POST /api/refreshFans`
+
+Fetch OnlyFans subscribers and followings and upsert them into the database without
+calling GPT. Returns `{ "fans": [...] }` with all stored fans.
+
+### `POST /api/updateParkerNames`
+
+Generate Parker names for any stored fans missing `parker_name`. Uses GPT‑4 and returns
+`{ "fans": [...] }` after updating the database.
 
 ### `GET /api/fans`
 

--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -92,10 +92,6 @@ test('inserts and retrieves fan with new columns', async () => {
     avatarThumbs: { foo: 1 }
   };
 
-  mockAxios.post.mockResolvedValueOnce({
-    data: { choices: [{ message: { content: 'Alice' } }] }
-  });
-
   mockAxios.get
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
@@ -103,7 +99,13 @@ test('inserts and retrieves fan with new columns', async () => {
     .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
-  await request(app).post('/api/updateFans').expect(200);
+  await request(app).post('/api/refreshFans').expect(200);
+
+  mockAxios.post.mockResolvedValueOnce({
+    data: { choices: [{ message: { content: 'Alice' } }] }
+  });
+
+  await request(app).post('/api/updateParkerNames').expect(200);
 
   const res = await request(app).get('/api/fans').expect(200);
   expect(res.body.fans).toHaveLength(1);
@@ -144,7 +146,7 @@ test('updates existing fan fields', async () => {
     avatarThumbs: { foo: 2 }
   };
 
-  mockAxios.post.mockResolvedValue({
+  mockAxios.post.mockResolvedValueOnce({
     data: { choices: [{ message: { content: 'Alice' } }] }
   });
 
@@ -162,8 +164,9 @@ test('updates existing fan fields', async () => {
     .mockResolvedValueOnce({ data: { data: { list: [fanData2] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
-  await request(app).post('/api/updateFans').expect(200); // insert
-  await request(app).post('/api/updateFans').expect(200); // update
+  await request(app).post('/api/refreshFans').expect(200); // insert
+  await request(app).post('/api/updateParkerNames').expect(200);
+  await request(app).post('/api/refreshFans').expect(200); // update
 
   const res = await request(app).get('/api/fans').expect(200);
   expect(res.body.fans).toHaveLength(1);
@@ -182,10 +185,6 @@ test('upserts followings with Parker names', async () => {
   const fanData = { id: 1, username: 'user1', name: 'Profile One' };
   const followingData = { id: 2, username: 'user2', name: 'Profile Two' };
 
-  mockAxios.post
-    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
-    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
-
   mockAxios.get
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
@@ -193,7 +192,13 @@ test('upserts followings with Parker names', async () => {
     .mockResolvedValueOnce({ data: { data: { list: [followingData] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
-  await request(app).post('/api/updateFans').expect(200);
+  await request(app).post('/api/refreshFans').expect(200);
+
+  mockAxios.post
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
+
+  await request(app).post('/api/updateParkerNames').expect(200);
 
   const res = await request(app).get('/api/fans').expect(200);
   expect(res.body.fans).toHaveLength(2);
@@ -208,10 +213,6 @@ test('merges fans and followings without duplication', async () => {
   const followingDuplicate = { ...fanData, avatar: 'a2', isSubscribed: true };
   const followingData = { id: 2, username: 'user2', name: 'Profile Two', avatar: 'b1' };
 
-  mockAxios.post
-    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
-    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
-
   mockAxios.get
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
@@ -219,7 +220,13 @@ test('merges fans and followings without duplication', async () => {
     .mockResolvedValueOnce({ data: { data: { list: [followingDuplicate, followingData] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
-  await request(app).post('/api/updateFans').expect(200);
+  await request(app).post('/api/refreshFans').expect(200);
+
+  mockAxios.post
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
+
+  await request(app).post('/api/updateParkerNames').expect(200);
 
   const res = await request(app).get('/api/fans').expect(200);
   expect(res.body.fans).toHaveLength(2);
@@ -234,10 +241,6 @@ test('fetches active fans and followings when filter is active', async () => {
   const fanData = { id: 1, username: 'user1', name: 'Profile One' };
   const followingData = { id: 2, username: 'user2', name: 'Profile Two' };
 
-  mockAxios.post
-    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
-    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
-
   mockAxios.get
     .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
     .mockResolvedValueOnce({ data: { data: { list: [fanData] } } })
@@ -245,7 +248,13 @@ test('fetches active fans and followings when filter is active', async () => {
     .mockResolvedValueOnce({ data: { data: { list: [followingData] } } })
     .mockResolvedValueOnce({ data: { data: { list: [] } } });
 
-  await request(app).post('/api/updateFans?filter=active').expect(200);
+  await request(app).post('/api/refreshFans?filter=active').expect(200);
+
+  mockAxios.post
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Alice' } }] } })
+    .mockResolvedValueOnce({ data: { choices: [{ message: { content: 'Bob' } }] } });
+
+  await request(app).post('/api/updateParkerNames').expect(200);
 
   expect(mockAxios.get.mock.calls[1][0]).toBe('/acc1/fans/active');
   expect(mockAxios.get.mock.calls[3][0]).toBe('/acc1/following/active');

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,8 @@
   </header>
   <h1>OnlyFans Express Messenger (OFEM)</h1>
   <p>
-    <button id="updateBtn" class="btn btn-primary">Update Fan Names</button>
+    <button id="refreshBtn" class="btn btn-primary">Update Fan List</button>
+    <button id="updateBtn" class="btn btn-primary">Update Parker Names</button>
     <button class="btn btn-primary" onclick="location.href='ppv.html'">PPV Manager</button>
     <a href="history.html" target="_blank">Message History</a>
     <a href="queue.html" target="_blank">Scheduled Queue</a>
@@ -247,17 +248,19 @@
       }
     }
 
-    async function updateFansList() {
+    async function refreshFansList() {
+      const refreshBtn = document.getElementById('refreshBtn');
       const updateBtn = document.getElementById('updateBtn');
       const sendBtn = document.getElementById('sendBtn');
+      refreshBtn.disabled = true;
       updateBtn.disabled = true;
       sendBtn.disabled = true;
-      document.getElementById('statusMsg').innerText = 'Updating fan list...';
+      document.getElementById('statusMsg').innerText = 'Refreshing fan list...';
       try {
-        const res = await fetch('/api/updateFans', { method: 'POST' });
+        const res = await fetch('/api/refreshFans', { method: 'POST' });
         if (!res.ok) {
           const errText = await res.text();
-          document.getElementById('statusMsg').innerText = 'Update failed: ' + errText;
+          document.getElementById('statusMsg').innerText = 'Refresh failed: ' + errText;
         } else {
           const data = await res.json();
           fansData = data.fans || [];
@@ -265,9 +268,37 @@
           document.getElementById('statusMsg').innerText = 'Loaded ' + fansData.length + ' fans.';
         }
       } catch (err) {
-        console.error('Update fans error:', err);
+        console.error('Refresh fans error:', err);
+        document.getElementById('statusMsg').innerText = 'Refresh failed: ' + err;
+      } finally {
+        refreshBtn.disabled = false;
+        updateBtn.disabled = false;
+        sendBtn.disabled = (fansData.length === 0);
+      }
+    }
+
+    async function updateParkerNames() {
+      const refreshBtn = document.getElementById('refreshBtn');
+      const updateBtn = document.getElementById('updateBtn');
+      const sendBtn = document.getElementById('sendBtn');
+      refreshBtn.disabled = true;
+      updateBtn.disabled = true;
+      sendBtn.disabled = true;
+      document.getElementById('statusMsg').innerText = 'Updating Parker names...';
+      try {
+        const res = await fetch('/api/updateParkerNames', { method: 'POST' });
+        if (!res.ok) {
+          const errText = await res.text();
+          document.getElementById('statusMsg').innerText = 'Update failed: ' + errText;
+        } else {
+          await fetchFans();
+          document.getElementById('statusMsg').innerText = 'Parker names updated.';
+        }
+      } catch (err) {
+        console.error('Update Parker names error:', err);
         document.getElementById('statusMsg').innerText = 'Update failed: ' + err;
       } finally {
+        refreshBtn.disabled = false;
         updateBtn.disabled = false;
         sendBtn.disabled = (fansData.length === 0);
       }
@@ -293,6 +324,7 @@
       clearStatusDots();
       sendingInProgress = true;
       abortFlag = false;
+      document.getElementById('refreshBtn').disabled = true;
       document.getElementById('updateBtn').disabled = true;
       document.getElementById('sendBtn').disabled = true;
       document.getElementById('abortBtn').disabled = false;
@@ -354,6 +386,7 @@
       // Finished sending loop
       sendingInProgress = false;
       document.getElementById('abortBtn').disabled = true;
+      document.getElementById('refreshBtn').disabled = false;
       document.getElementById('updateBtn').disabled = false;
       document.getElementById('sendBtn').disabled = false;
       if (abortFlag) {
@@ -401,7 +434,8 @@
       }
     }
 
-    document.getElementById('updateBtn').addEventListener('click', updateFansList);
+    document.getElementById('refreshBtn').addEventListener('click', refreshFansList);
+    document.getElementById('updateBtn').addEventListener('click', updateParkerNames);
     document.getElementById('sendBtn').addEventListener('click', sendMessagesToAll);
     document.getElementById('scheduleBtn').addEventListener('click', scheduleMessages);
     document.getElementById('loadVaultBtn').addEventListener('click', loadVaultMedia);


### PR DESCRIPTION
## Summary
- add `/api/refreshFans` to sync followers/followings without GPT
- add `/api/updateParkerNames` to fill missing parker_name values via GPT-4
- update dashboard to separate fan sync from Parker name enrichment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689052c67b948321927992d4c73a6597