### PR TITLE
Show placeholder for pending Parker names

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -183,6 +183,9 @@
         input.type = 'text';
         input.id = `name-${id}`;
         input.value = parkerName;
+        if (!parkerName) {
+          input.placeholder = 'Pending';
+        }
         input.className = 'form-input';
         tdParker.appendChild(input);
         tr.appendChild(tdParker);
@@ -291,7 +294,9 @@
           const errText = await res.text();
           document.getElementById('statusMsg').innerText = 'Update failed: ' + errText;
         } else {
-          await fetchFans();
+          const data = await res.json();
+          fansData = data.fans || [];
+          renderFansTable();
           document.getElementById('statusMsg').innerText = 'Parker names updated.';
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- Show a "Pending" placeholder in Parker Name cells when no name exists
- Refresh fans table with new Parker names after GPT update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890578364f48321a199354ad45837cb