### PR TITLE
fix: avoid hanging refresh fans request

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -264,7 +264,11 @@
       sendBtn.disabled = true;
       document.getElementById('statusMsg').innerText = 'Updating fan list...';
       try {
-        const res = await fetch('/api/refreshFans', { method: 'POST' });
+        const res = await fetch('/api/refreshFans', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}'
+        });
         if (!res.ok) {
           const errText = await res.text();
           document.getElementById('statusMsg').innerText = 'Fan list update failed: ' + errText;


### PR DESCRIPTION
## Summary
- send an empty JSON payload when refreshing fans so Express completes the request

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890794771dc832188819de5be5fd089