### PR TITLE
Allow price for locked-text messages without media

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -192,6 +192,23 @@ test('forwards media and price fields', async () => {
   });
 });
 
+test('allows price when lockedText true without media', async () => {
+  await mockPool.query("INSERT INTO fans (id, parker_name, username, location) VALUES (1, 'Alice', 'user1', 'Wonderland')");
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValueOnce({});
+  await request(app)
+    .post('/api/sendMessage')
+    .send({ userId: 1, greeting: '', body: 'Hello', price: 5, lockedText: true })
+    .expect(200);
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
+    text: '<p>Hello</p>',
+    mediaFiles: [],
+    previews: [],
+    price: 5,
+    lockedText: true
+  });
+});
+
 
 test('writes message record after successful send', async () => {
   await mockPool.query("INSERT INTO fans (id, parker_name, username, location) VALUES (1, 'Alice', 'user1', 'Wonderland')");

--- a/server.js
+++ b/server.js
@@ -790,11 +790,12 @@ app.post('/api/sendMessage', async (req, res) => {
                 // Deduplicate previews
                 previews = Array.from(new Set(previews));
 
-                // Parse price; default to 0 if NaN or no media files
-                let price = parseFloat(req.body.price);
-                if (isNaN(price) || mediaFiles.length === 0) price = 0;
-
+                // Determine whether text should be locked
                 const lockedText = req.body.lockedText === true;
+
+                // Parse price; default to 0 if NaN or neither media nor locked text
+                let price = parseFloat(req.body.price);
+                if (isNaN(price) || (mediaFiles.length === 0 && !lockedText)) price = 0;
 
                 await sendPersonalizedMessage(fanId, greeting, body, price, lockedText, mediaFiles, previews);
                 res.json({ success: true });


### PR DESCRIPTION
## Summary
- allow a non-zero price when only `lockedText` is supplied in `/api/sendMessage`
- test sending priced locked-text messages without media

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68907fe244bc8321a7809788e4c6f8d4