### PR TITLE
feat: fail fast when database unavailable

### DIFF
--- a/db.js
+++ b/db.js
@@ -40,6 +40,7 @@ async function ensureDatabaseExists() {
         }
     } catch (err) {
         console.error(`Error ensuring database exists: ${err.message}`);
+        throw err; // Rethrow to allow caller to handle and exit appropriately
     } finally {
         await client.end();
     }
@@ -47,7 +48,12 @@ async function ensureDatabaseExists() {
 
 // Immediately ensure the database exists before proceeding
 (async () => {
-    await ensureDatabaseExists();
+    try {
+        await ensureDatabaseExists();
+    } catch (err) {
+        // Fail fast if database setup is incorrect
+        process.exit(1);
+    }
 })();
 
 // Create a connection pool to the application database


### PR DESCRIPTION
## Summary
- throw errors from `ensureDatabaseExists` so startup can handle failures
- exit process with code 1 when DB initialization fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689080ef22748321b068693220590686