### PR TITLE
Normalize media and preview IDs in message endpoint

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -181,12 +181,12 @@ test('forwards media and price fields', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, greeting: '', body: 'Hello', price: 5, lockedText: true, mediaFiles: ['m1', 'm1', 'p1'], previews: ['p1', 'p1'] })
+    .send({ userId: 1, greeting: '', body: 'Hello', price: 5, lockedText: true, mediaFiles: [1, 1, 2], previews: [2, 2] })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
     text: '<p>Hello</p>',
-    mediaFiles: ['m1'],
-    previews: ['p1'],
+    mediaFiles: [1],
+    previews: [],
     price: 5,
     lockedText: true
   });


### PR DESCRIPTION
## Summary
- Ensure `/api/sendMessage` numericates and sanitizes `mediaFiles` and `previews` before sending
- Update media/preview deduplication to drop overlapping IDs and keep arrays numeric
- Adjust tests to cover new numeric media/preview behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890831dc2e083219f63364fccf1b7e4