### PR TITLE
Prompt for fields when editing scheduled messages

### DIFF
--- a/public/queue.js
+++ b/public/queue.js
@@ -40,17 +40,36 @@ window.Queue = {
     }
   },
   async edit(m) {
-    const combined = [m.greeting || '', m.body || ''].filter(Boolean).join(' ').trim();
-    const newBody = prompt('Edit message:', combined);
+    const newGreeting = prompt('New greeting:', m.greeting || '');
+    if (newGreeting === null) return;
+    const newBody = prompt('New message body:', m.body || '');
     if (newBody === null) return;
+    const priceInput = prompt('New price:', m.price != null ? m.price : '');
+    if (priceInput === null) return;
+    const lockedInput = prompt('New locked text:', m.locked_text || '');
+    if (lockedInput === null) return;
     const defaultTime = m.scheduled_at ? m.scheduled_at.slice(0,16) : '';
     const newTime = prompt('New schedule time (YYYY-MM-DDTHH:MM):', defaultTime);
     if (newTime === null) return;
+    const payload = {};
+    if (newGreeting.trim() !== '') payload.greeting = newGreeting;
+    if (newBody.trim() !== '') payload.body = newBody;
+    if (priceInput.trim() !== '') {
+      const priceNum = parseFloat(priceInput);
+      if (!isNaN(priceNum)) payload.price = priceNum;
+    }
+    if (lockedInput.trim() !== '') {
+      const lower = lockedInput.trim().toLowerCase();
+      if (lower === 'true') payload.lockedText = true;
+      else if (lower === 'false') payload.lockedText = false;
+      else payload.lockedText = lockedInput;
+    }
+    if (newTime.trim() !== '') payload.scheduledTime = newTime;
     try {
       await fetch(`/api/scheduledMessages/${m.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ body: newBody, scheduledTime: newTime })
+        body: JSON.stringify(payload)
       });
       this.fetch();
     } catch (err) {


### PR DESCRIPTION
## Summary
- allow editing scheduled messages to prompt separately for greeting, body, price, locked text, and schedule time
- build a conditional update payload and refresh the queue once the update completes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890834c65e083218963af2f753fd88d