### PR TITLE
feat: make OpenAI model configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ ONLYFANS_API_KEY=your_onlyfans_api_key_here
 # OpenAI API Key (for GPT-4 integration, if used)
 OPENAI_API_KEY=your_openai_api_key_here
 
+# OpenAI model for generating Parker names (optional, defaults to gpt-4o-mini)
+OPENAI_MODEL=gpt-4o-mini
+
 # PostgreSQL Database settings
 DB_NAME=ofem                      # Name of the PostgreSQL database for OFEM
 DB_USER=postgres                  # Database username (default PostgreSQL user is "postgres")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Steps
 1. Run `npm install`.
-2. Configure environment variables via `./setup-env.command` or `node setup-env.js`.
+2. Configure environment variables via `./setup-env.command` or `node setup-env.js` (set `OPENAI_MODEL` to override the default `gpt-4o-mini`).
 3. Create the database using `./setup-db.command` or `node setup-db.js`.
 4. Start the server with `npm start`.
 
@@ -20,7 +20,7 @@
      ```json
      { "fans": [{ "id": 1, "username": "demo", "parker_name": null }] }
      ```
-2. `POST /api/updateParkerNames` – fill in missing `parker_name` values using GPT‑4.
+2. `POST /api/updateParkerNames` – fill in missing `parker_name` values using the configured OpenAI model (default `gpt-4o-mini`).
    - Example response:
      ```json
      { "fans": [{ "id": 1, "username": "demo", "parker_name": "Spark" }] }
@@ -28,13 +28,13 @@
 3. `GET /api/fans` – retrieve the full list from the database once names are populated.
 
 ### `POST /api/refreshFans`
-Fetch OnlyFans subscribers and followings and upsert them in the database without GPT.
+Fetch OnlyFans subscribers and followings and upsert them in the database without calling OpenAI.
 - **Request Body:** none (requires `ONLYFANS_API_KEY`).
 - **Response:** `200` with `{ "fans": [{...}] }`.
 
 ### `POST /api/updateParkerNames`
-Generate Parker names for stored fans missing `parker_name` using GPT‑4.
-- **Request Body:** none (requires `OPENAI_API_KEY`).
+Generate Parker names for stored fans missing `parker_name` using the configured OpenAI model.
+- **Request Body:** none (requires `OPENAI_API_KEY`; optional `OPENAI_MODEL`).
 - **Response:** `200` with `{ "fans": [{...}] }`.
 
 ### `POST /api/sendMessage`

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 OFEM is a small dashboard that helps an OnlyFans creator greet fans by name and send a
 personalised message to everyone in one pass.  It uses the official OnlyFans API to
-fetch the fan list and send direct messages and OpenAI GPT‑4 to generate friendly
+fetch the fan list and send direct messages and an OpenAI GPT model (default `gpt-4o-mini`) to generate friendly
 nicknames.
 
 ## Features
 
 - **Update Fan List** – Fetches all subscribers and followings and stores them in the
-  database without calling GPT.
-- **Update Parker Names** – Generates a short “Parker name” with GPT‑4 only for fans who
+  database without calling OpenAI.
+- **Update Parker Names** – Generates a short “Parker name” with the configured OpenAI model (default `gpt-4o-mini`) only for fans who
   do not already have one. Names can be edited and saved.
 - **Send Personalised DM** – Sends a message to every fan, greeting each with their
   Parker name.  Shows a green dot for success and red for failure.  Sending can be
@@ -46,8 +46,9 @@ nicknames.
 The server reads the following variables from your environment or `.env` file:
 
 - `ONLYFANS_API_KEY` – authenticates requests to the OnlyFans API.
-- `OPENAI_API_KEY` – enables OpenAI GPT‑4 for generating Parker names (required only
+- `OPENAI_API_KEY` – enables OpenAI GPT models for generating Parker names (required only
   for `/api/updateParkerNames`).
+- `OPENAI_MODEL` – OpenAI model to use for Parker name generation (default `gpt-4o-mini`).
 - `DB_NAME` – name of the PostgreSQL database to use.
 - `DB_USER` – PostgreSQL username.
 - `DB_PASSWORD` – password for the database user.
@@ -169,7 +170,7 @@ Run `./addtodatabase.command` to apply both migrations to an existing database i
 ### `POST /api/refreshFans`
 
 Fetch OnlyFans subscribers and followings and upsert them into the database without
-calling GPT. Returns `{ "fans": [...] }` with all stored fans.
+calling OpenAI. Returns `{ "fans": [...] }` with all stored fans.
 
 #### Example response
 
@@ -179,7 +180,7 @@ calling GPT. Returns `{ "fans": [...] }` with all stored fans.
 
 ### `POST /api/updateParkerNames`
 
-Generate Parker names for any stored fans missing `parker_name`. Uses GPT‑4 and returns
+Generate Parker names for any stored fans missing `parker_name`. Uses the configured OpenAI model and returns
 `{ "fans": [...] }` after updating the database.
 
 #### Example response

--- a/server.js
+++ b/server.js
@@ -30,6 +30,8 @@ const ofApi = axios.create({
         timeout: 30000
 });
 const openaiAxios = axios.create({ timeout: 30000 });
+// OpenAI model configuration with fallback
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
 let OFAccountId = null;
 const REQUIRED_ENV_VARS = ['ONLYFANS_API_KEY', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'OPENAI_API_KEY'];
 // Configurable cap on OnlyFans records to fetch when paging. Prevents runaway loops if
@@ -568,7 +570,7 @@ Respond with only the chosen name.`;
                                                 openaiAxios.post(
                                                         'https://api.openai.com/v1/chat/completions',
                                                         {
-                                                                model: 'gpt-4',
+                                                                model: OPENAI_MODEL,
                                                                 messages: [
                                                                         { role: 'system', content: systemPrompt },
                                                                         { role: 'user', content: userPrompt }
@@ -580,7 +582,7 @@ Respond with only the chosen name.`;
                                                 )
                                         );
                                         parkerName = completion.data.choices[0].message.content.trim();
-                                        console.log(`GPT-4 name for ${username}: ${parkerName}`);
+                                        console.log(`${OPENAI_MODEL} name for ${username}: ${parkerName}`);
                                 }
 
                                 const originalName = parkerName;
@@ -1016,7 +1018,7 @@ app.get('/api/status', async (req, res) => {
                 files: { envFile: fs.existsSync(path.join(__dirname, '.env')) },
                 node: { version: process.version }
         };
-        const requiredEnv = ['ONLYFANS_API_KEY', 'OPENAI_API_KEY', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'DB_PORT'];
+        const requiredEnv = ['ONLYFANS_API_KEY', 'OPENAI_API_KEY', 'OPENAI_MODEL', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'DB_PORT'];
         requiredEnv.forEach(k => {
                 status.env[k] = !!process.env[k];
         });


### PR DESCRIPTION
## Summary
- allow configuring OpenAI model via `OPENAI_MODEL` env var with `gpt-4o-mini` default
- update `/api/updateParkerNames` to use the configurable model
- document `OPENAI_MODEL` in `.env.example`, `README.md`, and `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689286e265648321a16cd8b82c55e59b