### PR TITLE
Sanitize axios error logging

### DIFF
--- a/sanitizeError.js
+++ b/sanitizeError.js
@@ -1,0 +1,30 @@
+function sanitizeError(err) {
+  if (!err || typeof err !== 'object') return err;
+  const sanitized = {
+    message: err.message,
+    name: err.name,
+  };
+  if (err.stack) sanitized.stack = err.stack;
+  if (err.config) {
+    const cfg = { ...err.config };
+    if (err.config.headers) {
+      const headers = { ...err.config.headers };
+      for (const key of Object.keys(headers)) {
+        if (/authorization/i.test(key) || /cookie/i.test(key) || /api-key/i.test(key)) {
+          headers[key] = '[REDACTED]';
+        }
+      }
+      cfg.headers = headers;
+    }
+    sanitized.config = cfg;
+  }
+  if (err.response) {
+    sanitized.response = {
+      status: err.response.status,
+      data: err.response.data,
+      headers: err.response.headers,
+    };
+  }
+  return sanitized;
+}
+module.exports = { sanitizeError };


### PR DESCRIPTION
## Summary
- add `sanitizeError` helper to strip Authorization and similar headers from Axios error logs
- replace `console.error(err)` with `console.error(sanitizeError(err))` across API routes

## Testing
- `npm test`
- `node -e "const { sanitizeError } = require('./sanitizeError'); const err={message:'fail',config:{headers:{Authorization:'Bearer secret','x-api-key':'123'}}}; console.error(sanitizeError(err));"`

------
https://chatgpt.com/codex/tasks/task_e_689288ac751c83219070b69a098e0a04