### PR TITLE
Normalize numeric media IDs before dedupe

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -181,7 +181,15 @@ test('forwards media and price fields', async () => {
   mockAxios.post.mockResolvedValueOnce({});
   await request(app)
     .post('/api/sendMessage')
-    .send({ userId: 1, greeting: '', body: 'Hello', price: 5, lockedText: true, mediaFiles: [1, 1, 2], previews: [2, 2] })
+    .send({
+      userId: 1,
+      greeting: '',
+      body: 'Hello',
+      price: 5,
+      lockedText: true,
+      mediaFiles: [1, 'x', 1, 2],
+      previews: [2, 'y', 2]
+    })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
     text: '<p>Hello</p>',

--- a/server.js
+++ b/server.js
@@ -798,14 +798,10 @@ app.post('/api/sendMessage', async (req, res) => {
 
                 // Normalize and sanitize media and preview arrays
                 let mediaFiles = Array.isArray(req.body.mediaFiles)
-                        ? req.body.mediaFiles
-                                  .map((id) => Number(id))
-                                  .filter((id) => !isNaN(id))
+                        ? req.body.mediaFiles.map(Number).filter(Number.isFinite)
                         : [];
                 let previews = Array.isArray(req.body.previews)
-                        ? req.body.previews
-                                  .map((id) => Number(id))
-                                  .filter((id) => !isNaN(id))
+                        ? req.body.previews.map(Number).filter(Number.isFinite)
                         : [];
 
                 // Deduplicate and remove overlaps


### PR DESCRIPTION
## Summary
- normalize `mediaFiles` and `previews` to numeric IDs and remove non-numeric entries
- cover invalid media IDs in send message tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892cf5a54a883219a850a7be704097d