### PR TITLE
Enhance PPV Manager with scheduling and media preview controls

### DIFF
--- a/migrate_add_ppv_tables.js
+++ b/migrate_add_ppv_tables.js
@@ -17,6 +17,9 @@ CREATE TABLE IF NOT EXISTS ppv_sets (
     description TEXT,
     price DECIMAL(10,2) NOT NULL,
     vault_list_id BIGINT,
+    schedule_day INTEGER,
+    schedule_time TEXT,
+    last_sent_at TIMESTAMP,
     created_at TIMESTAMP DEFAULT NOW()
 );
 `;
@@ -37,6 +40,9 @@ ALTER TABLE ppv_sets
     ADD COLUMN IF NOT EXISTS description TEXT,
     ADD COLUMN IF NOT EXISTS price DECIMAL(10,2) NOT NULL,
     ADD COLUMN IF NOT EXISTS vault_list_id BIGINT,
+    ADD COLUMN IF NOT EXISTS schedule_day INTEGER,
+    ADD COLUMN IF NOT EXISTS schedule_time TEXT,
+    ADD COLUMN IF NOT EXISTS last_sent_at TIMESTAMP,
     ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT NOW();
 `;
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -161,8 +161,40 @@ input {
   min-height: 60px;
 }
 .vault-section { margin-top: 10px; }
-.vault-media-list { max-height: 150px; overflow: auto; margin-top: 5px; }
-.schedule-section { margin-top: 10px; }
+.vault-media-list {
+  max-height: 150px;
+  overflow: auto;
+  margin-top: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.media-item {
+  border: 1px solid var(--border-color);
+  padding: 5px;
+  text-align: center;
+}
+.media-item img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto 4px;
+}
+.media-item label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  font-size: 0.9em;
+}
+.schedule-section {
+  margin-top: 10px;
+  border: 1px solid var(--border-color);
+  padding: 10px;
+}
+.schedule-section legend {
+  font-weight: bold;
+}
 
 /* History page */
 ul { list-style: none; padding-left: 0; }

--- a/public/ppv.html
+++ b/public/ppv.html
@@ -36,6 +36,16 @@
     <div class="mb-8">
       <label>Price: <input type="number" id="price" min="0" step="0.01" class="form-input w-80" /></label>
     </div>
+    <fieldset class="schedule-section mb-8">
+      <legend>Scheduling</legend>
+      <label>Send every:
+        <select id="scheduleDay" class="form-input w-80"></select>
+      </label>
+      <label>Time:
+        <input type="time" id="scheduleTime" class="form-input w-200" />
+        <span>(EST)</span>
+      </label>
+    </fieldset>
     <div class="mb-8">
       <button id="loadVaultBtn" type="button" class="btn btn-primary">Load Vault Media</button>
       <div id="vaultMediaList" class="vault-media-list"></div>
@@ -64,6 +74,17 @@
       }
     }
 
+    function populateScheduleOptions() {
+      const daySelect = document.getElementById('scheduleDay');
+      daySelect.innerHTML = '';
+      for (let i = 1; i <= 31; i++) {
+        const opt = document.createElement('option');
+        opt.value = i;
+        opt.textContent = i;
+        daySelect.appendChild(opt);
+      }
+    }
+
     async function loadVaultMedia() {
       try {
         const res = await fetch('/api/vault-media');
@@ -74,31 +95,46 @@
         container.innerHTML = '';
         for (const m of items) {
           const div = document.createElement('div');
-          const mediaCb = document.createElement('input');
-          mediaCb.type = 'checkbox';
-          mediaCb.className = 'mediaCheckbox';
-          mediaCb.value = m.id;
-          div.appendChild(mediaCb);
-
-          const previewCb = document.createElement('input');
-          previewCb.type = 'checkbox';
-          previewCb.className = 'previewCheckbox';
-          previewCb.value = m.id;
-          div.appendChild(previewCb);
-
-          const span = document.createElement('span');
-          span.textContent = 'Media ' + m.id;
-          div.appendChild(span);
+          div.className = 'media-item';
 
           const thumb = (m.preview && (m.preview.url || m.preview.src)) ||
                         (m.thumb && (m.thumb.url || m.thumb.src));
           if (thumb) {
             const img = document.createElement('img');
             img.src = thumb;
-            img.width = 50;
-            img.style.marginLeft = '5px';
+            img.alt = `Media ${m.id}`;
             div.appendChild(img);
           }
+
+          const idSpan = document.createElement('div');
+          idSpan.textContent = `ID: ${m.id}`;
+          div.appendChild(idSpan);
+
+          const includeLabel = document.createElement('label');
+          const includeCb = document.createElement('input');
+          includeCb.type = 'checkbox';
+          includeCb.className = 'mediaCheckbox';
+          includeCb.value = m.id;
+          includeLabel.appendChild(includeCb);
+          includeLabel.appendChild(document.createTextNode(' Include'));
+
+          const previewLabel = document.createElement('label');
+          const previewCb = document.createElement('input');
+          previewCb.type = 'checkbox';
+          previewCb.className = 'previewCheckbox';
+          previewCb.value = m.id;
+          previewLabel.appendChild(previewCb);
+          previewLabel.appendChild(document.createTextNode(' Preview'));
+
+          includeCb.addEventListener('change', () => {
+            if (!includeCb.checked) previewCb.checked = false;
+          });
+          previewCb.addEventListener('change', () => {
+            if (previewCb.checked) includeCb.checked = true;
+          });
+
+          div.appendChild(includeLabel);
+          div.appendChild(previewLabel);
           container.appendChild(div);
         }
       } catch (err) {
@@ -110,19 +146,23 @@
       const ppvNumber = parseInt(document.getElementById('ppvNumber').value, 10);
       const description = document.getElementById('description').value.trim();
       const price = parseFloat(document.getElementById('price').value);
+      const scheduleDay = parseInt(document.getElementById('scheduleDay').value, 10);
+      const scheduleTime = document.getElementById('scheduleTime').value;
       const mediaFiles = Array.from(document.querySelectorAll('.mediaCheckbox:checked')).map(cb => Number(cb.value));
       const previews = Array.from(document.querySelectorAll('.previewCheckbox:checked')).map(cb => Number(cb.value));
       try {
         const res = await fetch('/api/ppv', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ppvNumber, description, price, mediaFiles, previews })
+          body: JSON.stringify({ ppvNumber, description, price, mediaFiles, previews, scheduleDay, scheduleTime })
         });
         const result = await res.json();
         if (res.ok) {
           document.getElementById('ppvNumber').value = '';
           document.getElementById('description').value = '';
           document.getElementById('price').value = '';
+          document.getElementById('scheduleDay').selectedIndex = 0;
+          document.getElementById('scheduleTime').value = '';
           document.getElementById('vaultMediaList').innerHTML = '';
           fetchPpvs();
         } else {
@@ -149,6 +189,7 @@
 
     document.getElementById('loadVaultBtn').addEventListener('click', loadVaultMedia);
     document.getElementById('saveBtn').addEventListener('click', savePpv);
+    populateScheduleOptions();
     fetchPpvs();
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -688,7 +688,7 @@ app.get('/api/vault-media', async (req, res) => {
 // PPV management endpoints
 app.get('/api/ppv', async (req, res) => {
         try {
-                const dbRes = await pool.query('SELECT id, ppv_number, description, price, vault_list_id, created_at FROM ppv_sets ORDER BY ppv_number');
+                const dbRes = await pool.query('SELECT id, ppv_number, description, price, vault_list_id, schedule_day, schedule_time, last_sent_at, created_at FROM ppv_sets ORDER BY ppv_number');
                 res.json({ ppvs: dbRes.rows });
         } catch (err) {
                 console.error('Error fetching PPVs:', sanitizeError(err));
@@ -697,9 +697,15 @@ app.get('/api/ppv', async (req, res) => {
 });
 
 app.post('/api/ppv', async (req, res) => {
-        const { ppvNumber, description, price, mediaFiles, previews } = req.body || {};
+        const { ppvNumber, description, price, mediaFiles, previews, scheduleDay, scheduleTime } = req.body || {};
         if (!Number.isInteger(ppvNumber) || typeof description !== 'string' || description.trim() === '' || !Number.isFinite(price) || !Array.isArray(mediaFiles) || mediaFiles.length === 0 || !Array.isArray(previews)) {
                 return res.status(400).json({ error: 'Invalid PPV data.' });
+        }
+        if (scheduleDay !== undefined && (!Number.isInteger(scheduleDay) || scheduleDay < 1 || scheduleDay > 31)) {
+                return res.status(400).json({ error: 'Invalid schedule day.' });
+        }
+        if (scheduleTime !== undefined && typeof scheduleTime !== 'string') {
+                return res.status(400).json({ error: 'Invalid schedule time.' });
         }
         let vaultListId;
         try {
@@ -720,7 +726,7 @@ app.post('/api/ppv', async (req, res) => {
                 let ppvRow;
                 try {
                         await client.query('BEGIN');
-                        const setRes = await client.query('INSERT INTO ppv_sets (ppv_number, description, price, vault_list_id) VALUES ($1,$2,$3,$4) RETURNING *', [ppvNumber, description, price, vaultListId]);
+                        const setRes = await client.query('INSERT INTO ppv_sets (ppv_number, description, price, vault_list_id, schedule_day, schedule_time) VALUES ($1,$2,$3,$4,$5,$6) RETURNING *', [ppvNumber, description, price, vaultListId, scheduleDay || null, scheduleTime || null]);
                         ppvRow = setRes.rows[0];
                         for (const mediaId of mediaFiles) {
                                 const isPreview = previews.includes(mediaId);


### PR DESCRIPTION
## Summary
- add scheduling fields to PPV form so creators can choose day and time for recurring sends
- improve vault media chooser with labeled Include/Preview checkboxes and preview-requires-include logic
- polish layout with grid styling for media items and styled scheduling section
- extend database schema and API to store recurring schedule info for PPV sets

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68943f1e54b48321999c19a93fd1d48d