### PR TITLE
Add follow page with follow now workflow

### DIFF
--- a/public/follow.html
+++ b/public/follow.html
@@ -15,7 +15,21 @@
       <a href="follow.html" class="btn btn-primary">Follow Fans and Followers</a>
     </nav>
   </header>
+
   <h1>Follow Fans and Followers</h1>
-  <p>Manage following fans and followers from this page.</p>
+  <p>Click "Follow Now" to follow all unfollowed fans and followers.</p>
+  <button id="followBtn" class="btn btn-primary">Follow Now</button>
+  <div id="statusMsg" class="status-msg"></div>
+  <table id="followTable" class="form-table">
+    <thead>
+      <tr>
+        <th>Username</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody id="followTableBody"></tbody>
+  </table>
+
+  <script src="follow.js"></script>
 </body>
 </html>

--- a/public/follow.js
+++ b/public/follow.js
@@ -1,0 +1,68 @@
+(function() {
+  let unfollowed = [];
+
+  function escapeHtml(str) {
+    return String(str).replace(/[&<>"']/g, c => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    })[c]);
+  }
+
+  async function loadUnfollowed() {
+    try {
+      const res = await fetch('/api/fans/unfollowed');
+      if (!res.ok) throw new Error('Failed to fetch unfollowed fans');
+      const data = await res.json();
+      unfollowed = data.fans || [];
+      renderTable();
+    } catch (err) {
+      console.error('Error loading unfollowed fans:', err);
+    }
+  }
+
+  function renderTable() {
+    const tbody = document.getElementById('followTableBody');
+    tbody.innerHTML = '';
+    unfollowed.forEach(fan => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td>' + escapeHtml(fan.username || '') + '</td>' +
+                     '<td id="status-' + fan.id + '"></td>';
+      tbody.appendChild(tr);
+    });
+    document.getElementById('followBtn').disabled = unfollowed.length === 0;
+  }
+
+  function setStatusDot(id, color) {
+    const el = document.getElementById('status-' + id);
+    if (el) {
+      el.innerHTML = '<span class="dot ' + escapeHtml(color) + '"></span>';
+    }
+  }
+
+  async function followAll() {
+    const total = unfollowed.length;
+    let success = 0;
+    for (const fan of unfollowed) {
+      try {
+        const res = await fetch('/api/fans/' + fan.id + '/follow', { method: 'POST' });
+        if (res.ok) {
+          setStatusDot(fan.id, 'green');
+          success++;
+        } else {
+          setStatusDot(fan.id, 'red');
+        }
+      } catch (err) {
+        console.error('Error following fan', fan.id, err);
+        setStatusDot(fan.id, 'red');
+      }
+      document.getElementById('statusMsg').innerText = 'Followed ' + success + ' of ' + total;
+      await new Promise(r => setTimeout(r, 500));
+    }
+  }
+
+  document.getElementById('followBtn').addEventListener('click', followAll);
+  loadUnfollowed();
+})();


### PR DESCRIPTION
## Summary
- Extend follow page with button, status area, and table to track followed fans
- Implement front-end logic to fetch unfollowed fans and follow them sequentially with progress updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68945e736c308321a39b1807384a2d5a