### PR TITLE
Add tests for follow endpoints and document follow page

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ Run `./addtodatabase.command` to apply both migrations to an existing database i
 6. Click **Send Personalised DM to All Fans** to start sending.  Use **Abort Sending**
    to stop early.
 
+## Follow Fans and Followers
+
+Open <http://localhost:3000/follow.html> to follow back users who are not yet
+subscribed. The page calls `GET /api/fans/unfollowed` to list accounts where
+`isSubscribed` is `false`. Selecting **Follow All** issues a `POST
+/api/fans/:id/follow` for each entry.
+
+Requests are throttled with a 500 ms delay to respect OnlyFans rate limits. The
+`ONLYFANS_API_KEY` environment variable must be set for the page to function.
+
 ## API
 
 ### Usage Sequence
@@ -241,7 +251,8 @@ Run the unit tests with:
 npm test
 ```
 
-Jest is the configured test runner, so contributors should ensure all tests pass before committing.
+Jest is the configured test runner and includes suites such as
+`__tests__/followFans.test.js`. Ensure all tests pass before committing.
 
 ## Notes
 

--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -316,28 +316,6 @@ test('retries OpenAI 500 errors and continues processing other fans', async () =
   expect(counts.user1).toBeGreaterThan(1);
 });
 
-test('GET /api/fans/unfollowed returns only unsubscribed fans', async () => {
-  await pool.query(
-    `INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false), (2, 'user2', true)`
-  );
-
-  const res = await request(app).get('/api/fans/unfollowed').expect(200);
-  expect(res.body.fans).toEqual([{ id: 1, username: 'user1' }]);
-});
-
-test('POST /api/fans/:id/follow calls OnlyFans API and updates DB', async () => {
-  await pool.query(`INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false)`);
-
-  mockAxios.get.mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } });
-  mockAxios.post.mockResolvedValueOnce({ data: {} });
-
-  await request(app).post('/api/fans/1/follow').expect(200);
-
-  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/users/1/follow');
-  const dbRes = await pool.query('SELECT isSubscribed FROM fans WHERE id=1');
-  expect(dbRes.rows[0].issubscribed).toBe(true);
-});
-
 test('POST /api/fans/followAll streams progress and updates DB', async () => {
   await pool.query(
     `INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false), (2, 'user2', false)`

--- a/__tests__/followFans.test.js
+++ b/__tests__/followFans.test.js
@@ -1,0 +1,56 @@
+const { newDb } = require('pg-mem');
+const mem = newDb();
+const pg = mem.adapters.createPg();
+const mockPool = new pg.Pool();
+
+jest.mock('../db', () => mockPool);
+jest.mock('axios');
+
+const request = require('supertest');
+const mockAxios = require('axios');
+const pool = require('../db');
+
+mockAxios.create.mockReturnValue(mockAxios);
+
+let app;
+
+beforeAll(async () => {
+  process.env.ONLYFANS_API_KEY = 'test';
+  process.env.OPENAI_API_KEY = 'test';
+  await pool.query(`
+    CREATE TABLE fans (
+      id BIGINT PRIMARY KEY,
+      username TEXT,
+      isSubscribed BOOLEAN
+    );
+  `);
+  app = require('../server');
+});
+
+beforeEach(async () => {
+  await pool.query('DELETE FROM fans');
+  mockAxios.get.mockReset();
+  mockAxios.post.mockReset();
+});
+
+test('GET /api/fans/unfollowed returns only unsubscribed fans', async () => {
+  await pool.query(
+    "INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false), (2, 'user2', true)"
+  );
+
+  const res = await request(app).get('/api/fans/unfollowed').expect(200);
+  expect(res.body.fans).toEqual([{ id: 1, username: 'user1' }]);
+});
+
+test('POST /api/fans/:id/follow calls OnlyFans API and updates DB', async () => {
+  await pool.query("INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false)");
+
+  mockAxios.get.mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValueOnce({ data: {} });
+
+  await request(app).post('/api/fans/1/follow').expect(200);
+
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/users/1/follow');
+  const dbRes = await pool.query('SELECT isSubscribed FROM fans WHERE id=1');
+  expect(dbRes.rows[0].issubscribed).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add `followFans.test.js` for OnlyFans follow/unfollow endpoints
- document Follow Fans and Followers page with rate limit and env var info
- mention follow test in README testing section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689463e4fec08321be70e877ee2bca57