### PR TITLE
Validate PPV scheduling inputs

### DIFF
--- a/__tests__/ppv.test.js
+++ b/__tests__/ppv.test.js
@@ -1,0 +1,103 @@
+const { newDb } = require('pg-mem');
+const mem = newDb();
+const pg = mem.adapters.createPg();
+const mockPool = new pg.Pool();
+
+jest.mock('../db', () => mockPool);
+jest.mock('axios');
+
+const request = require('supertest');
+const mockAxios = require('axios');
+mockAxios.create.mockReturnValue(mockAxios);
+
+let app;
+
+beforeAll(async () => {
+  process.env.ONLYFANS_API_KEY = 'test';
+  process.env.OPENAI_API_KEY = 'test';
+  process.env.DB_NAME = 'testdb';
+  process.env.DB_USER = 'user';
+  process.env.DB_PASSWORD = 'pass';
+  await mockPool.query(`
+    CREATE TABLE ppv_sets (
+      id BIGSERIAL PRIMARY KEY,
+      ppv_number INTEGER UNIQUE,
+      description TEXT,
+      price NUMERIC NOT NULL,
+      vault_list_id BIGINT,
+      schedule_day INTEGER,
+      schedule_time TEXT,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+  await mockPool.query(`
+    CREATE TABLE ppv_media (
+      ppv_id BIGINT REFERENCES ppv_sets(id) ON DELETE CASCADE,
+      media_id BIGINT,
+      is_preview BOOLEAN
+    );
+  `);
+  app = require('../server');
+});
+
+beforeEach(async () => {
+  await mockPool.query('DELETE FROM ppv_media');
+  await mockPool.query('DELETE FROM ppv_sets');
+  mockAxios.get.mockReset();
+  mockAxios.post.mockReset();
+});
+
+test('accepts valid schedule inputs', async () => {
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post
+    .mockResolvedValueOnce({ data: { id: 1 } })
+    .mockResolvedValueOnce({});
+
+  const res = await request(app)
+    .post('/api/ppv')
+    .send({
+      ppvNumber: 1,
+      description: 'desc',
+      price: 5,
+      mediaFiles: [1],
+      previews: [],
+      scheduleDay: 15,
+      scheduleTime: '13:30'
+    });
+
+  expect(res.status).toBe(201);
+  expect(res.body.ppv.schedule_day).toBe(15);
+  expect(res.body.ppv.schedule_time).toBe('13:30');
+});
+
+test('rejects invalid scheduleDay', async () => {
+  const res = await request(app)
+    .post('/api/ppv')
+    .send({
+      ppvNumber: 1,
+      description: 'desc',
+      price: 5,
+      mediaFiles: [1],
+      previews: [],
+      scheduleDay: 0,
+      scheduleTime: '13:30'
+    });
+  expect(res.status).toBe(400);
+  expect(res.body).toEqual({ error: expect.stringContaining('scheduleDay') });
+});
+
+test('rejects invalid scheduleTime', async () => {
+  const res = await request(app)
+    .post('/api/ppv')
+    .send({
+      ppvNumber: 1,
+      description: 'desc',
+      price: 5,
+      mediaFiles: [1],
+      previews: [],
+      scheduleDay: 10,
+      scheduleTime: '25:00'
+    });
+  expect(res.status).toBe(400);
+  expect(res.body).toEqual({ error: expect.stringContaining('scheduleTime') });
+});

--- a/server.js
+++ b/server.js
@@ -705,20 +705,27 @@ app.get('/api/ppv', async (req, res) => {
 });
 
 app.post('/api/ppv', async (req, res) => {
-const { ppvNumber, description, price, mediaFiles, previews, scheduleDay, scheduleTime } = req.body || {};
-let dayValid = true;
-let timeValid = true;
-if (scheduleDay != null || scheduleTime != null) {
-dayValid = Number.isInteger(scheduleDay) && scheduleDay >= 1 && scheduleDay <= 31;
-timeValid = typeof scheduleTime === 'string' && /^\d{2}:\d{2}$/.test(scheduleTime);
-if (timeValid) {
-const [h, m] = scheduleTime.split(':').map(Number);
-timeValid = h >= 0 && h < 24 && m >= 0 && m < 60;
-}
-}
-if (!Number.isInteger(ppvNumber) || typeof description !== 'string' || description.trim() === '' || !Number.isFinite(price) || !Array.isArray(mediaFiles) || mediaFiles.length === 0 || !Array.isArray(previews) || scheduleDay == null !== (scheduleTime == null) || !dayValid || !timeValid) {
-return res.status(400).json({ error: 'Invalid PPV data.' });
-}
+        const { ppvNumber, description, price, mediaFiles, previews, scheduleDay, scheduleTime } = req.body || {};
+
+        if ((scheduleDay == null) !== (scheduleTime == null)) {
+                return res.status(400).json({ error: 'Both scheduleDay and scheduleTime must be provided together' });
+        }
+        if (scheduleDay != null) {
+                if (!Number.isInteger(scheduleDay) || scheduleDay < 1 || scheduleDay > 31) {
+                        return res.status(400).json({ error: 'scheduleDay must be an integer between 1 and 31' });
+                }
+                if (typeof scheduleTime !== 'string' || !/^\d{2}:\d{2}$/.test(scheduleTime)) {
+                        return res.status(400).json({ error: 'scheduleTime must be in HH:MM format' });
+                }
+                const [h, m] = scheduleTime.split(':').map(Number);
+                if (h < 0 || h > 23 || m < 0 || m > 59) {
+                        return res.status(400).json({ error: 'scheduleTime must be in 24-hour HH:MM format' });
+                }
+        }
+
+        if (!Number.isInteger(ppvNumber) || typeof description !== 'string' || description.trim() === '' || !Number.isFinite(price) || !Array.isArray(mediaFiles) || mediaFiles.length === 0 || !Array.isArray(previews)) {
+                return res.status(400).json({ error: 'Invalid PPV data.' });
+        }
         let vaultListId;
         try {
                 if (!OFAccountId) {


### PR DESCRIPTION
## Summary
- enforce strict scheduleDay and scheduleTime validation in `/api/ppv`
- add unit tests covering valid and invalid scheduling scenarios

## Testing
- `npm test -- __tests__/ppv.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6894b1dfbfd083218593deb0ac715f36