### PR TITLE
Standardize PPV schedule fields to camelCase

### DIFF
--- a/__tests__/ppv.test.js
+++ b/__tests__/ppv.test.js
@@ -66,8 +66,8 @@ test('accepts valid schedule inputs', async () => {
     });
 
   expect(res.status).toBe(201);
-  expect(res.body.ppv.schedule_day).toBe(15);
-  expect(res.body.ppv.schedule_time).toBe('13:30');
+  expect(res.body.ppv.scheduleDay).toBe(15);
+  expect(res.body.ppv.scheduleTime).toBe('13:30');
 });
 
 test('rejects invalid scheduleDay', async () => {

--- a/public/ppv.html
+++ b/public/ppv.html
@@ -101,7 +101,7 @@
       tbody.innerHTML = '';
       for (const p of ppvs) {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.description}</td><td>${p.price}</td><td>${p.schedule_day ?? ''}</td><td>${p.schedule_time ?? ''}</td><td><button class="btn btn-secondary" onclick="deletePpv(${p.id})">Delete</button></td>`;
+        tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.description}</td><td>${p.price}</td><td>${p.scheduleDay ?? ''}</td><td>${p.scheduleTime ?? ''}</td><td><button class="btn btn-secondary" onclick="deletePpv(${p.id})">Delete</button></td>`;
         tbody.appendChild(tr);
       }
     }


### PR DESCRIPTION
## Summary
- Front-end PPV manager now sends and displays `scheduleDay`/`scheduleTime` values
- API maps camelCase schedule fields to `schedule_day` and `schedule_time` DB columns and returns camelCase
- Update recurring PPV scheduler and tests to use camelCase naming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894b3dd9e008321ac4ec616384400fa