### PR TITLE
test: add scheduler recurrence tests

### DIFF
--- a/__tests__/scheduler.test.js
+++ b/__tests__/scheduler.test.js
@@ -1,0 +1,110 @@
+const { newDb } = require('pg-mem');
+const mem = newDb();
+const pg = mem.adapters.createPg();
+const mockPool = new pg.Pool();
+
+jest.mock('../db', () => mockPool);
+jest.mock('axios');
+const mockAxios = require('axios');
+mockAxios.create.mockReturnValue(mockAxios);
+
+let app;
+let processRecurringPPVs;
+
+beforeAll(async () => {
+  process.env.ONLYFANS_API_KEY = 'test';
+  process.env.OPENAI_API_KEY = 'test';
+  process.env.DB_NAME = 'testdb';
+  process.env.DB_USER = 'user';
+  process.env.DB_PASSWORD = 'pass';
+
+  await mockPool.query(`
+    CREATE TABLE fans (
+      id BIGSERIAL PRIMARY KEY,
+      username TEXT,
+      isSubscribed BOOLEAN,
+      canReceiveChatMessage BOOLEAN
+    );
+  `);
+
+  await mockPool.query(`
+    CREATE TABLE ppv_sets (
+      id BIGSERIAL PRIMARY KEY,
+      ppv_number INTEGER UNIQUE,
+      description TEXT,
+      price NUMERIC NOT NULL,
+      vault_list_id BIGINT,
+      schedule_day INTEGER,
+      schedule_time TEXT,
+      last_sent_at TIMESTAMP,
+      created_at TIMESTAMP DEFAULT NOW()
+    );
+  `);
+
+  await mockPool.query(`
+    CREATE TABLE ppv_media (
+      ppv_id BIGINT REFERENCES ppv_sets(id) ON DELETE CASCADE,
+      media_id BIGINT,
+      is_preview BOOLEAN
+    );
+  `);
+
+  await mockPool.query(`
+    CREATE TABLE messages (
+      fan_id BIGINT,
+      direction TEXT,
+      body TEXT,
+      price NUMERIC
+    );
+  `);
+
+  app = require('../server');
+  ({ processRecurringPPVs } = app);
+});
+
+beforeEach(async () => {
+  await mockPool.query('DELETE FROM ppv_media');
+  await mockPool.query('DELETE FROM ppv_sets');
+  await mockPool.query('DELETE FROM fans');
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+test('recurring PPVs send once per fan per month across cycles', async () => {
+  await mockPool.query(`INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE), (2, TRUE, TRUE);`);
+  await mockPool.query(`INSERT INTO ppv_sets (id, description, price, schedule_day, schedule_time) VALUES (1, 'desc', 5, 15, '10:00');`);
+  await mockPool.query(`INSERT INTO ppv_media (ppv_id, media_id, is_preview) VALUES (1, 100, FALSE);`);
+
+  jest.useFakeTimers();
+  const sendSpy = jest.fn().mockResolvedValue();
+  app._setSendPersonalizedMessage(sendSpy);
+  mockAxios.get.mockResolvedValue({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValue({ data: {} });
+
+  async function runScheduler() {
+    const promise = processRecurringPPVs();
+    await jest.runAllTimersAsync();
+    return promise;
+  }
+
+  jest.setSystemTime(new Date('2024-01-15T10:05:00Z'));
+  await runScheduler();
+  expect(sendSpy).toHaveBeenCalledTimes(2);
+
+  await runScheduler();
+  expect(sendSpy).toHaveBeenCalledTimes(2);
+
+  jest.setSystemTime(new Date('2024-02-15T10:05:00Z'));
+  await runScheduler();
+  expect(sendSpy).toHaveBeenCalledTimes(4);
+
+  await runScheduler();
+  expect(sendSpy).toHaveBeenCalledTimes(4);
+
+  jest.setSystemTime(new Date('2024-03-15T10:05:00Z'));
+  await runScheduler();
+  expect(sendSpy).toHaveBeenCalledTimes(6);
+});

--- a/server.js
+++ b/server.js
@@ -162,7 +162,7 @@ function removeEmojis(str = "") {
         return str.replace(/\p{Extended_Pictographic}/gu, "");
 }
 
-async function sendPersonalizedMessage(
+let sendPersonalizedMessage = async function (
         fanId,
         greeting = "",
         body = "",
@@ -216,7 +216,7 @@ async function sendPersonalizedMessage(
         if (payload.mediaFiles.length) logMsg += ` [media:${payload.mediaFiles.length}]`;
         if (payload.price) logMsg += ` [price:${payload.price}]`;
 console.log(logMsg);
-}
+};
 
 
 
@@ -1341,5 +1341,10 @@ if (require.main === module) {
 // Export app for testing
 module.exports = app;
 module.exports.shouldSendNow = shouldSendNow;
+module.exports.processRecurringPPVs = processRecurringPPVs;
+module.exports.sendPersonalizedMessage = (...args) => sendPersonalizedMessage(...args);
+module.exports._setSendPersonalizedMessage = fn => {
+        sendPersonalizedMessage = fn;
+};
 
 /* End of File – Last modified 2025-08-02 */


### PR DESCRIPTION
## Summary
- expose and allow overriding `sendPersonalizedMessage` for testing
- add scheduler test ensuring PPVs send once per fan per monthly cycle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894c693673483218e71887fdcd06fa9