### PR TITLE
Add combined migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ their purposes are:
 - `price` – media price
 - `created_at` – timestamp when the message was created
 
-Run `./addtodatabase.command` to apply both migrations to an existing database in one step.
+Run `./addtodatabase.command` or `node migrate_all.js` to apply all migrations to an existing database in one step.
 
 ## Usage
 

--- a/addtodatabase.command
+++ b/addtodatabase.command
@@ -2,7 +2,7 @@
 # OnlyFans Express Messenger (OFEM) - Migration Runner
 # Usage: Double-click this file or run in Terminal to apply non-destructive migrations.
 # Created: 2025-08-05 – v1.0
-# Includes migrations for scheduled messages and PPV tables.
+# Runs all database migrations via migrate_all.js.
 
 set -e
 cd "$(dirname "$0")"
@@ -24,9 +24,5 @@ if [ "$missing" = true ]; then
   npm install >/dev/null
 fi
 
-node migrate_add_fan_fields.js
-node migrate_messages.js
-node migrate_scheduled_messages.js
-node migrate_add_ppv_tables.js
-node migrate_add_ppv_schedule_fields.js
+node migrate_all.js
 

--- a/migrate_all.js
+++ b/migrate_all.js
@@ -1,0 +1,29 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate_all.js
+   Purpose: Run all database migration scripts sequentially
+   Created: 2025-??-?? – v1.0
+*/
+
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const scripts = [
+    'migrate_add_fan_fields.js',
+    'migrate_messages.js',
+    'migrate_scheduled_messages.js',
+    'migrate_add_ppv_tables.js',
+    'migrate_add_ppv_schedule_fields.js',
+];
+
+for (const script of scripts) {
+    console.log(`➡️  Running ${script}`);
+    const result = spawnSync('node', [path.join(__dirname, script)], { stdio: 'inherit' });
+    if (result.status !== 0) {
+        console.error(`❌ Migration failed for ${script}`);
+        process.exit(result.status || 1);
+    }
+}
+
+console.log('✅ All migrations complete.');
+
+/* End of File – Last modified 2025-??-?? */


### PR DESCRIPTION
## Summary
- add `migrate_all.js` to sequentially run all database migrations
- simplify `addtodatabase.command` to use the new migration runner
- document `node migrate_all.js` as the single entry point for migrations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f21b675c83219a0377328489c437