### PR TITLE
Fail migrations loudly on errors

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -124,8 +124,10 @@ ALTER TABLE fans
         console.log('✅ "fans" table has been created/updated.');
     } catch (err) {
         console.error('Error running migration:', err.message);
+        process.exitCode = 1;
     } finally {
         await pool.end();
+        if (process.exitCode) process.exit(process.exitCode);
     }
 })();
 

--- a/migrate_add_fan_fields.js
+++ b/migrate_add_fan_fields.js
@@ -65,8 +65,10 @@ const columns = [
         console.log('✅ Fan fields migration complete.');
     } catch (err) {
         console.error('Error running fan fields migration:', err.message);
+        process.exitCode = 1;
     } finally {
         await pool.end();
+        if (process.exitCode) process.exit(process.exitCode);
     }
 })();
 

--- a/migrate_add_ppv_schedule_fields.js
+++ b/migrate_add_ppv_schedule_fields.js
@@ -37,8 +37,10 @@ ALTER TABLE IF EXISTS ppv_sets
         console.log("✅ 'ppv_sets' table altered with scheduling fields.");
     } catch (err) {
         console.error('Error running PPV schedule migration:', err.message);
+        process.exitCode = 1;
     } finally {
         await pool.end();
+        if (process.exitCode) process.exit(process.exitCode);
     }
 })();
 

--- a/migrate_add_ppv_tables.js
+++ b/migrate_add_ppv_tables.js
@@ -57,8 +57,10 @@ ALTER TABLE ppv_media
         console.log("✅ 'ppv_sets' and 'ppv_media' tables created.");
     } catch (err) {
         console.error('Error running PPV tables migration:', err.message);
+        process.exitCode = 1;
     } finally {
         await pool.end();
+        if (process.exitCode) process.exit(process.exitCode);
     }
 })();
 

--- a/migrate_messages.js
+++ b/migrate_messages.js
@@ -27,8 +27,10 @@ CREATE TABLE IF NOT EXISTS messages (
         console.log('✅ "messages" table has been created/updated.');
     } catch (err) {
         console.error('Error running messages migration:', err.message);
+        process.exitCode = 1;
     } finally {
         await pool.end();
+        if (process.exitCode) process.exit(process.exitCode);
     }
 })();
 

--- a/migrate_scheduled_messages.js
+++ b/migrate_scheduled_messages.js
@@ -32,8 +32,10 @@ CREATE TABLE IF NOT EXISTS scheduled_messages (
         console.log('✅ "scheduled_messages" table has been created/updated.');
     } catch (err) {
         console.error('Error running scheduled_messages migration:', err.message);
+        process.exitCode = 1;
     } finally {
         await pool.end();
+        if (process.exitCode) process.exit(process.exitCode);
     }
 })();
 


### PR DESCRIPTION
## Summary
- ensure fan field migration sets exit code on failure
- propagate errors from other migration scripts so migrate_all.js aborts

## Testing
- `npm test` *(fails: Test Suites: 1 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689534567bec8321b63fcdbf50d9328f