### PR TITLE
Handle missing database creation privileges gracefully

### DIFF
--- a/db.js
+++ b/db.js
@@ -54,6 +54,17 @@ async function ensureDatabaseExists() {
     const client = new Client(defaultConfig);
     try {
         await client.connect();
+    } catch (err) {
+        if (err.code === '42501' || /permission denied/i.test(err.message)) {
+            console.warn(`⚠️  Permission denied to connect to default database "postgres". ` +
+                        `Database "${DB_NAME}" must be created manually.`);
+            return;
+        }
+        console.error(`Error connecting to default database: ${err.message}`);
+        throw err;
+    }
+
+    try {
         await client.query(`CREATE DATABASE ${DB_NAME}`);
         console.log(`✅ Database "${DB_NAME}" created successfully.`);
     } catch (err) {


### PR DESCRIPTION
## Summary
- avoid crashing when database user lacks CREATE DATABASE permissions
- warn and skip DB creation if connection or CREATE fails with permission error

## Testing
- `npm test` *(fails: fans.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689537df45d88321ac3b1c52f50268c9