### PR TITLE
Display user-facing alerts on client errors

### DIFF
--- a/public/follow.js
+++ b/public/follow.js
@@ -20,6 +20,7 @@
       renderTable();
     } catch (err) {
       console.error('Error loading unfollowed fans:', err);
+      alert('Failed to fetch unfollowed fans');
     }
   }
 
@@ -70,11 +71,13 @@
         }
       } catch (err) {
         console.error('Error parsing SSE data', err);
+        alert('Error processing follow response');
       }
     };
 
     source.onerror = err => {
       console.error('SSE error', err);
+      alert('Error following fans');
       source.close();
       document.getElementById('followBtn').disabled = false;
     };

--- a/public/history.js
+++ b/public/history.js
@@ -1,23 +1,37 @@
 (function(global){
   async function fetchFans(){
-    const res = await global.fetch('/api/fans');
-    if(!res.ok) throw new Error('Failed to fetch fans');
-    const data = await res.json();
-    return data.fans || [];
+    try {
+      const res = await global.fetch('/api/fans');
+      if(!res.ok) throw new Error('Failed to fetch fans');
+      const data = await res.json();
+      return data.fans || [];
+    } catch (err) {
+      global.alert('Failed to fetch fans');
+      throw err;
+    }
   }
 
   async function populateFanSelect(){
-    const fans = await fetchFans();
-    const sel = global.document.getElementById('fanSelect');
-    if(!sel) return;
-    sel.innerHTML = fans.map(f => '<option value="'+ f.id +'">'+ escapeHtml(f.username || f.name || f.parker_name || String(f.id)) +'</option>').join('');
+    try {
+      const fans = await fetchFans();
+      const sel = global.document.getElementById('fanSelect');
+      if(!sel) return;
+      sel.innerHTML = fans.map(f => '<option value="'+ f.id +'">'+ escapeHtml(f.username || f.name || f.parker_name || String(f.id)) +'</option>').join('');
+    } catch (err) {
+      console.error('Error populating fan select', err);
+    }
   }
 
   async function fetchMessageHistory(fanId, limit){
-    const res = await global.fetch(`/api/messages/history?fanId=${fanId}&limit=${limit}`);
-    if(!res.ok) throw new Error('Failed to fetch message history');
-    const data = await res.json();
-    return data.messages || [];
+    try {
+      const res = await global.fetch(`/api/messages/history?fanId=${fanId}&limit=${limit}`);
+      if(!res.ok) throw new Error('Failed to fetch message history');
+      const data = await res.json();
+      return data.messages || [];
+    } catch (err) {
+      global.alert('Failed to fetch message history');
+      throw err;
+    }
   }
 
   function renderMessageHistory(messages){
@@ -30,8 +44,12 @@
   async function handleFetch(){
     const fanId = global.document.getElementById('fanSelect').value;
     const limit = global.document.getElementById('limitInput').value || 20;
-    const msgs = await fetchMessageHistory(fanId, limit);
-    renderMessageHistory(msgs);
+    try {
+      const msgs = await fetchMessageHistory(fanId, limit);
+      renderMessageHistory(msgs);
+    } catch (err) {
+      console.error('Error fetching message history', err);
+    }
   }
 
   function escapeHtml(str){

--- a/public/queue.js
+++ b/public/queue.js
@@ -2,10 +2,12 @@ window.Queue = {
   async fetch() {
     try {
       const res = await fetch('/api/scheduledMessages');
+      if (!res.ok) throw new Error('Failed to fetch scheduled messages');
       const data = await res.json();
       this.render(data.messages || []);
     } catch (err) {
       console.error('Error fetching scheduled messages:', err);
+      alert('Error fetching scheduled messages');
     }
   },
   render(messages) {
@@ -33,10 +35,12 @@ window.Queue = {
   },
   async cancel(id) {
     try {
-      await fetch(`/api/scheduledMessages/${id}`, { method: 'DELETE' });
+      const res = await fetch(`/api/scheduledMessages/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to cancel message');
       this.fetch();
     } catch (err) {
       console.error('Error canceling message:', err);
+      alert('Error canceling message');
     }
   },
   async edit(m) {
@@ -71,9 +75,11 @@ window.Queue = {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
-      if (res.ok) this.fetch();
+      if (!res.ok) throw new Error('Failed to edit message');
+      this.fetch();
     } catch (err) {
       console.error('Error editing message:', err);
+      alert('Error editing message');
     }
   }
 };


### PR DESCRIPTION
## Summary
- Alert users when fan list or message history retrieval fails
- Notify users if scheduled message operations fail in the queue
- Surface errors during unfollowed fan loading or follow-all operation

## Testing
- `npm test` *(fails: 1 failed, 11 passed, 12 total)*

------
https://chatgpt.com/codex/tasks/task_e_68954e92076483219f6b686fc4aecd94