### PR TITLE
feat: auto refresh scheduled queue

### DIFF
--- a/public/queue.html
+++ b/public/queue.html
@@ -15,6 +15,7 @@
     </nav>
   </header>
   <h1>Scheduled Message Queue</h1>
+  <button id="refreshBtn" class="btn btn-secondary">Refresh</button>
   <table id="queueTable" class="form-table">
     <thead>
       <tr>

--- a/public/queue.js
+++ b/public/queue.js
@@ -84,4 +84,9 @@ window.Queue = {
   }
 };
 
-document.addEventListener('DOMContentLoaded', () => Queue.fetch());
+document.addEventListener('DOMContentLoaded', () => {
+  Queue.fetch();
+  const refreshBtn = document.getElementById('refreshBtn');
+  if (refreshBtn) refreshBtn.addEventListener('click', () => Queue.fetch());
+  setInterval(() => Queue.fetch(), 60000);
+});


### PR DESCRIPTION
## Summary
- add refresh button to queue UI
- auto-refresh scheduled messages every 60s

## Testing
- `npm test` *(fails: __tests__/fans.test.js: Unmatched parameter in query $44)*

------
https://chatgpt.com/codex/tasks/task_e_6895682d795083219339833f62a4d5e4