### PR TITLE
feat: add modal editing for scheduled messages

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -205,6 +205,31 @@ input {
   padding: 0 5px;
 }
 
+/* Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  max-width: 400px;
+  width: 100%;
+}
+
 /* History page */
 ul { list-style: none; padding-left: 0; }
 li { margin-bottom: 4px; }

--- a/public/queue.html
+++ b/public/queue.html
@@ -27,6 +27,32 @@
     </thead>
     <tbody></tbody>
   </table>
+  <div id="editModal" class="modal">
+    <div class="modal-content">
+      <h2>Edit Scheduled Message</h2>
+      <form id="editForm">
+        <label>Message
+          <textarea id="editBody" class="form-input"></textarea>
+        </label>
+        <label class="mt-5">Schedule Time
+          <input type="datetime-local" id="editTime" class="form-input">
+        </label>
+        <label class="mt-5">Greeting
+          <input type="text" id="editGreeting" class="form-input">
+        </label>
+        <label class="mt-5">Price
+          <input type="number" id="editPrice" class="form-input">
+        </label>
+        <label class="mt-5">
+          <input type="checkbox" id="editLocked"> Lock message
+        </label>
+        <div class="mt-10">
+          <button type="submit" class="btn btn-primary">Save</button>
+          <button type="button" id="editCancel" class="btn btn-secondary">Cancel</button>
+        </div>
+      </form>
+    </div>
+  </div>
   <script src="queue.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace prompt-based editing with a modal form for scheduled messages
- validate datetime, price and lock status before updating messages
- add basic modal styling and markup

## Testing
- `npm test` *(fails: Unmatched parameter in query $44)*

------
https://chatgpt.com/codex/tasks/task_e_689568e43f6083219494d26ca3d1dff0