### PR TITLE
refactor: unify front-end modules under App namespace

### DIFF
--- a/public/editor.js
+++ b/public/editor.js
@@ -81,19 +81,18 @@
     sel.addRange(range);
   }
 
-  global.applySize = applySize;
-  global.applyColor = applyColor;
-  global.applyBold = applyBold;
-  global.applyItalic = applyItalic;
-  global.insertPlaceholder = insertPlaceholder;
+  const Editor = {
+    applySize,
+    applyColor,
+    applyBold,
+    applyItalic,
+    insertPlaceholder,
+  };
+
+  global.App = global.App || {};
+  global.App.Editor = Editor;
 
   if (typeof module !== 'undefined') {
-    module.exports = {
-      applySize,
-      applyColor,
-      applyBold,
-      applyItalic,
-      insertPlaceholder,
-    };
+    module.exports = Editor;
   }
 })(typeof window !== 'undefined' ? window : global);

--- a/public/history.html
+++ b/public/history.html
@@ -33,8 +33,8 @@
     <div id="messageHistory" class="mt-15"></div>
     <script src="history.js"></script>
     <script>
-      if (window.MessageHistory && MessageHistory.init) {
-        MessageHistory.init();
+      if (window.App && App.MessageHistory && App.MessageHistory.init) {
+        App.MessageHistory.init();
       }
     </script>
   </body>

--- a/public/history.js
+++ b/public/history.js
@@ -88,13 +88,16 @@
     if (btn) btn.addEventListener('click', handleFetch);
   }
 
-  const api = {
+  const MessageHistory = {
     fetchMessageHistory,
     renderMessageHistory,
     handleFetch,
     populateFanSelect,
     init,
   };
-  if (typeof module !== 'undefined') module.exports = api;
-  else global.MessageHistory = api;
+
+  global.App = global.App || {};
+  global.App.MessageHistory = MessageHistory;
+
+  if (typeof module !== 'undefined') module.exports = MessageHistory;
 })(typeof window !== 'undefined' ? window : global);

--- a/public/index.html
+++ b/public/index.html
@@ -474,7 +474,7 @@
         const previews = Array.from(
           document.querySelectorAll('.previewCheckbox:checked'),
         ).map((cb) => cb.value);
-        clearStatusDots();
+        App.Results.clearStatusDots();
         sendingInProgress = true;
         abortFlag = false;
         document.getElementById('refreshBtn').disabled = true;
@@ -511,7 +511,7 @@
             if (result.success) {
               // Success: mark green
               setStatusDot(fanId, 'green');
-              addResult({
+              App.Results.addResult({
                 fanId,
                 username: fan.username || '',
                 parkerName: fan.parker_name || '',
@@ -522,7 +522,7 @@
             } else {
               // Failure: mark red
               setStatusDot(fanId, 'red');
-              addResult({
+              App.Results.addResult({
                 fanId,
                 username: fan.username || '',
                 parkerName: fan.parker_name || '',
@@ -542,7 +542,7 @@
             console.error('Error sending to fan ' + fanId + ':', err);
             // Treat network or unexpected error as failure
             setStatusDot(fanId, 'red');
-            addResult({
+            App.Results.addResult({
               fanId,
               username: fan.username || '',
               parkerName: fan.parker_name || '',
@@ -663,27 +663,29 @@
         });
       document
         .getElementById('clearStatusBtn')
-        .addEventListener('click', clearStatusDots);
+        .addEventListener('click', App.Results.clearStatusDots);
       document
         .getElementById('downloadBtn')
-        .addEventListener('click', downloadResults);
+        .addEventListener('click', App.Results.downloadResults);
 
       document
         .getElementById('sizeSelect')
-        .addEventListener('change', (e) => applySize(e.target.value));
+        .addEventListener('change', (e) => App.Editor.applySize(e.target.value));
       document
         .getElementById('colorSelect')
-        .addEventListener('change', (e) => applyColor(e.target.value));
-      document.getElementById('boldBtn').addEventListener('click', applyBold);
+        .addEventListener('change', (e) => App.Editor.applyColor(e.target.value));
+      document
+        .getElementById('boldBtn')
+        .addEventListener('click', App.Editor.applyBold);
       document
         .getElementById('italicBtn')
-        .addEventListener('click', applyItalic);
+        .addEventListener('click', App.Editor.applyItalic);
       document
         .getElementById('placeholderSelect')
         .addEventListener('change', (e) => {
           const val = e.target.value;
           if (val) {
-            insertPlaceholder(val);
+            App.Editor.insertPlaceholder(val);
             e.target.value = '';
           }
         });

--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -1,12 +1,12 @@
-(function () {
+(function (global) {
   async function fetchPpvs() {
     try {
-      const res = await fetch('/api/ppv');
+      const res = await global.fetch('/api/ppv');
       if (!res.ok) return;
       const data = await res.json();
       renderPpvTable(data.ppvs || []);
     } catch (err) {
-      console.error('Error fetching PPVs:', err);
+      global.console.error('Error fetching PPVs:', err);
     }
   }
 
@@ -20,13 +20,14 @@
   }
 
   function renderPpvTable(ppvs) {
-    const tbody = document.getElementById('ppvTableBody');
+    const tbody = global.document.getElementById('ppvTableBody');
+    if (!tbody) return;
     tbody.innerHTML = '';
     for (const p of ppvs) {
       const day = p.scheduleDay != null ? p.scheduleDay : 'None';
       const time = p.scheduleTime ? formatTime(p.scheduleTime) : 'None';
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.description}</td><td>${p.price}</td><td>${day}</td><td>${time}</td><td><button class="btn btn-secondary" onclick="deletePpv(${p.id})">Delete</button></td>`;
+      const tr = global.document.createElement('tr');
+      tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.description}</td><td>${p.price}</td><td>${day}</td><td>${time}</td><td><button class="btn btn-secondary" onclick="App.PPV.deletePpv(${p.id})">Delete</button></td>`;
       tbody.appendChild(tr);
     }
   }
@@ -44,34 +45,35 @@
 
   async function loadVaultMedia() {
     try {
-      const res = await fetch('/api/vault-media');
+      const res = await global.fetch('/api/vault-media');
       if (!res.ok) return;
       const data = await res.json();
       const items = Array.isArray(data)
         ? data
         : data.list || data.results || data.media || data.data || [];
-      const container = document.getElementById('vaultMediaList');
+      const container = global.document.getElementById('vaultMediaList');
+      if (!container) return;
       container.innerHTML = '';
       for (const m of items) {
-        const div = document.createElement('div');
+        const div = global.document.createElement('div');
         div.className = 'media-item';
 
         const thumb =
           (m.preview && (m.preview.url || m.preview.src)) ||
           (m.thumb && (m.thumb.url || m.thumb.src));
         if (thumb) {
-          const img = document.createElement('img');
+          const img = global.document.createElement('img');
           img.src = thumb;
           div.appendChild(img);
         }
 
-        const idSpan = document.createElement('span');
+        const idSpan = global.document.createElement('span');
         idSpan.className = 'media-id';
         idSpan.textContent = 'ID: ' + m.id;
         div.appendChild(idSpan);
 
-        const includeLabel = document.createElement('label');
-        const mediaCb = document.createElement('input');
+        const includeLabel = global.document.createElement('label');
+        const mediaCb = global.document.createElement('input');
         mediaCb.type = 'checkbox';
         mediaCb.className = 'mediaCheckbox';
         mediaCb.value = m.id;
@@ -79,8 +81,8 @@
         includeLabel.append(' Include');
         div.appendChild(includeLabel);
 
-        const previewLabel = document.createElement('label');
-        const previewCb = document.createElement('input');
+        const previewLabel = global.document.createElement('label');
+        const previewCb = global.document.createElement('input');
         previewCb.type = 'checkbox';
         previewCb.className = 'previewCheckbox';
         previewCb.value = m.id;
@@ -93,25 +95,25 @@
         container.appendChild(div);
       }
     } catch (err) {
-      console.error('Error loading vault media:', err);
+      global.console.error('Error loading vault media:', err);
     }
   }
 
   async function savePpv() {
-    const ppvNumber = parseInt(document.getElementById('ppvNumber').value, 10);
-    const description = document.getElementById('description').value.trim();
-    const price = parseFloat(document.getElementById('price').value);
+    const ppvNumber = parseInt(global.document.getElementById('ppvNumber').value, 10);
+    const description = global.document.getElementById('description').value.trim();
+    const price = parseFloat(global.document.getElementById('price').value);
     const mediaFiles = Array.from(
-      document.querySelectorAll('.mediaCheckbox:checked'),
+      global.document.querySelectorAll('.mediaCheckbox:checked'),
     ).map((cb) => Number(cb.value));
     const previews = Array.from(
-      document.querySelectorAll('.previewCheckbox:checked'),
+      global.document.querySelectorAll('.previewCheckbox:checked'),
     ).map((cb) => Number(cb.value));
-    const scheduleDayVal = document.getElementById('scheduleDay').value;
-    const scheduleTime = document.getElementById('scheduleTime').value;
+    const scheduleDayVal = global.document.getElementById('scheduleDay').value;
+    const scheduleTime = global.document.getElementById('scheduleTime').value;
     const scheduleDay = scheduleDayVal ? parseInt(scheduleDayVal, 10) : null;
     try {
-      const res = await fetch('/api/ppv', {
+      const res = await global.fetch('/api/ppv', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -126,40 +128,60 @@
       });
       const result = await res.json();
       if (res.ok) {
-        document.getElementById('ppvNumber').value = '';
-        document.getElementById('description').value = '';
-        document.getElementById('price').value = '';
-        document.getElementById('scheduleDay').value = '';
-        document.getElementById('scheduleTime').value = '';
-        document.getElementById('vaultMediaList').innerHTML = '';
+        global.document.getElementById('ppvNumber').value = '';
+        global.document.getElementById('description').value = '';
+        global.document.getElementById('price').value = '';
+        global.document.getElementById('scheduleDay').value = '';
+        global.document.getElementById('scheduleTime').value = '';
+        global.document.getElementById('vaultMediaList').innerHTML = '';
         fetchPpvs();
       } else {
-        alert(result.error || 'Failed to save PPV');
+        global.alert(result.error || 'Failed to save PPV');
       }
     } catch (err) {
-      console.error('Error saving PPV:', err);
+      global.console.error('Error saving PPV:', err);
     }
   }
 
   async function deletePpv(id) {
-    if (!confirm('Delete this PPV?')) return;
+    if (!global.confirm('Delete this PPV?')) return;
     try {
-      const res = await fetch(`/api/ppv/${id}`, { method: 'DELETE' });
+      const res = await global.fetch(`/api/ppv/${id}`, { method: 'DELETE' });
       if (res.ok) {
         fetchPpvs();
       } else {
-        alert('Failed to delete PPV');
+        global.alert('Failed to delete PPV');
       }
     } catch (err) {
-      console.error('Error deleting PPV:', err);
+      global.console.error('Error deleting PPV:', err);
     }
   }
 
-  window.deletePpv = deletePpv;
+  function init() {
+    const loadBtn = global.document.getElementById('loadVaultBtn');
+    if (loadBtn) loadBtn.addEventListener('click', loadVaultMedia);
+    const saveBtn = global.document.getElementById('saveBtn');
+    if (saveBtn) saveBtn.addEventListener('click', savePpv);
+    fetchPpvs();
+  }
 
-  document
-    .getElementById('loadVaultBtn')
-    .addEventListener('click', loadVaultMedia);
-  document.getElementById('saveBtn').addEventListener('click', savePpv);
-  fetchPpvs();
-})();
+  const PPV = {
+    fetchPpvs,
+    formatTime,
+    renderPpvTable,
+    linkPreviewInclude,
+    loadVaultMedia,
+    savePpv,
+    deletePpv,
+    init,
+  };
+
+  global.App = global.App || {};
+  global.App.PPV = PPV;
+
+  if (typeof module !== 'undefined') {
+    module.exports = PPV;
+  }
+
+  global.document.addEventListener('DOMContentLoaded', init);
+})(typeof window !== 'undefined' ? window : global);

--- a/public/queue.js
+++ b/public/queue.js
@@ -1,142 +1,152 @@
-window.Queue = {
-  async fetch() {
-    try {
-      const res = await fetch('/api/scheduledMessages');
-      if (!res.ok) throw new Error('Failed to fetch scheduled messages');
-      const data = await res.json();
-      this.render(data.messages || []);
-    } catch (err) {
-      console.error('Error fetching scheduled messages:', err);
-      alert('Error fetching scheduled messages');
-    }
-  },
-  init() {
-    this.editModal = document.getElementById('editModal');
-    this.editForm = document.getElementById('editForm');
-    this.editBody = document.getElementById('editBody');
-    this.editTime = document.getElementById('editTime');
-    this.editGreeting = document.getElementById('editGreeting');
-    this.editPrice = document.getElementById('editPrice');
-    this.editLocked = document.getElementById('editLocked');
-    this.currentMessage = null;
-    if (this.editForm) {
-      this.editForm.addEventListener('submit', (e) => this.submitEdit(e));
-    }
-    const cancelBtn = document.getElementById('editCancel');
-    if (cancelBtn) cancelBtn.addEventListener('click', () => this.hideEdit());
-  },
-  render(messages) {
-    const tbody = document.querySelector('#queueTable tbody');
-    tbody.innerHTML = '';
-    for (const m of messages) {
-      const tr = document.createElement('tr');
-      const msgText = [m.greeting || '', m.body || '']
-        .filter(Boolean)
-        .join(' ')
-        .trim();
-      const time = m.scheduled_at
-        ? new Date(m.scheduled_at).toLocaleString()
-        : '';
-      tr.innerHTML = `<td>${m.id}</td><td>${msgText}</td><td>${time}</td>`;
-      const actionsTd = document.createElement('td');
-      const editBtn = document.createElement('button');
-      editBtn.textContent = 'Edit';
-      editBtn.className = 'btn btn-secondary';
-      editBtn.addEventListener('click', () => this.edit(m));
-      const cancelBtn = document.createElement('button');
-      cancelBtn.textContent = 'Cancel';
-      cancelBtn.className = 'btn btn-secondary';
-      cancelBtn.addEventListener('click', () => this.cancel(m.id));
-      actionsTd.appendChild(editBtn);
-      actionsTd.appendChild(cancelBtn);
-      tr.appendChild(actionsTd);
-      tbody.appendChild(tr);
-    }
-  },
-  async cancel(id) {
-    try {
-      const res = await fetch(`/api/scheduledMessages/${id}`, {
-        method: 'DELETE',
-      });
-      if (!res.ok) throw new Error('Failed to cancel message');
-      this.fetch();
-    } catch (err) {
-      console.error('Error canceling message:', err);
-      alert('Error canceling message');
-    }
-  },
-  edit(m) {
-    this.currentMessage = m;
-    if (this.editBody) this.editBody.value = m.body || '';
-    if (this.editTime)
-      this.editTime.value = m.scheduled_at ? m.scheduled_at.slice(0, 16) : '';
-    if (this.editGreeting) this.editGreeting.value = m.greeting || '';
-    if (this.editPrice) this.editPrice.value = m.price != null ? m.price : '';
-    if (this.editLocked) this.editLocked.checked = !!m.locked_text;
-    if (this.editModal) this.editModal.classList.add('show');
-  },
-  hideEdit() {
-    if (this.editModal) this.editModal.classList.remove('show');
-    this.currentMessage = null;
-  },
-  async submitEdit(e) {
-    e.preventDefault();
-    if (!this.currentMessage) return;
-    const payload = {};
-    const body = this.editBody.value.trim();
-    const time = this.editTime.value.trim();
-    const greeting = this.editGreeting.value;
-    const price = this.editPrice.value.trim();
-    const locked = this.editLocked.checked;
-    if (body !== '') payload.body = body;
-    if (time !== '') {
-      const re = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
-      if (!re.test(time)) {
-        alert('Time must be in YYYY-MM-DDTHH:MM format');
-        return;
+(function (global) {
+  const Queue = {
+    async fetch() {
+      try {
+        const res = await global.fetch('/api/scheduledMessages');
+        if (!res.ok) throw new Error('Failed to fetch scheduled messages');
+        const data = await res.json();
+        this.render(data.messages || []);
+      } catch (err) {
+        global.console.error('Error fetching scheduled messages:', err);
+        global.alert('Error fetching scheduled messages');
       }
-      const scheduledDate = new Date(time);
-      if (isNaN(scheduledDate.getTime()) || scheduledDate < new Date()) {
-        alert('Scheduled time cannot be in the past');
-        return;
+    },
+    init() {
+      this.editModal = global.document.getElementById('editModal');
+      this.editForm = global.document.getElementById('editForm');
+      this.editBody = global.document.getElementById('editBody');
+      this.editTime = global.document.getElementById('editTime');
+      this.editGreeting = global.document.getElementById('editGreeting');
+      this.editPrice = global.document.getElementById('editPrice');
+      this.editLocked = global.document.getElementById('editLocked');
+      this.currentMessage = null;
+      if (this.editForm) {
+        this.editForm.addEventListener('submit', (e) => this.submitEdit(e));
       }
-      payload.scheduledTime = time;
-    }
-    payload.greeting = greeting;
-    if (price !== '') {
-      const priceNum = Number(price);
-      if (isNaN(priceNum)) {
-        alert('Price must be a number');
-        return;
+      const cancelBtn = global.document.getElementById('editCancel');
+      if (cancelBtn) cancelBtn.addEventListener('click', () => this.hideEdit());
+    },
+    render(messages) {
+      const tbody = global.document.querySelector('#queueTable tbody');
+      if (!tbody) return;
+      tbody.innerHTML = '';
+      for (const m of messages) {
+        const tr = global.document.createElement('tr');
+        const msgText = [m.greeting || '', m.body || '']
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+        const time = m.scheduled_at
+          ? new Date(m.scheduled_at).toLocaleString()
+          : '';
+        tr.innerHTML = `<td>${m.id}</td><td>${msgText}</td><td>${time}</td>`;
+        const actionsTd = global.document.createElement('td');
+        const editBtn = global.document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.className = 'btn btn-secondary';
+        editBtn.addEventListener('click', () => this.edit(m));
+        const cancelBtn = global.document.createElement('button');
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.className = 'btn btn-secondary';
+        cancelBtn.addEventListener('click', () => this.cancel(m.id));
+        actionsTd.appendChild(editBtn);
+        actionsTd.appendChild(cancelBtn);
+        tr.appendChild(actionsTd);
+        tbody.appendChild(tr);
       }
-      payload.price = priceNum;
-    } else {
-      payload.price = null;
-    }
-    payload.lockedText = locked;
-    try {
-      const res = await fetch(
-        `/api/scheduledMessages/${this.currentMessage.id}`,
-        {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        },
-      );
-      if (!res.ok) throw new Error('Failed to edit message');
-      this.hideEdit();
-      this.fetch();
-    } catch (err) {
-      console.error('Error editing message:', err);
-      alert('Error editing message');
-    }
-  },
-};
+    },
+    async cancel(id) {
+      try {
+        const res = await global.fetch(`/api/scheduledMessages/${id}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) throw new Error('Failed to cancel message');
+        this.fetch();
+      } catch (err) {
+        global.console.error('Error canceling message:', err);
+        global.alert('Error canceling message');
+      }
+    },
+    edit(m) {
+      this.currentMessage = m;
+      if (this.editBody) this.editBody.value = m.body || '';
+      if (this.editTime)
+        this.editTime.value = m.scheduled_at ? m.scheduled_at.slice(0, 16) : '';
+      if (this.editGreeting) this.editGreeting.value = m.greeting || '';
+      if (this.editPrice) this.editPrice.value = m.price != null ? m.price : '';
+      if (this.editLocked) this.editLocked.checked = !!m.locked_text;
+      if (this.editModal) this.editModal.classList.add('show');
+    },
+    hideEdit() {
+      if (this.editModal) this.editModal.classList.remove('show');
+      this.currentMessage = null;
+    },
+    async submitEdit(e) {
+      e.preventDefault();
+      if (!this.currentMessage) return;
+      const payload = {};
+      const body = this.editBody.value.trim();
+      const time = this.editTime.value.trim();
+      const greeting = this.editGreeting.value;
+      const price = this.editPrice.value.trim();
+      const locked = this.editLocked.checked;
+      if (body !== '') payload.body = body;
+      if (time !== '') {
+        const re = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/;
+        if (!re.test(time)) {
+          global.alert('Time must be in YYYY-MM-DDTHH:MM format');
+          return;
+        }
+        const scheduledDate = new Date(time);
+        if (isNaN(scheduledDate.getTime()) || scheduledDate < new Date()) {
+          global.alert('Scheduled time cannot be in the past');
+          return;
+        }
+        payload.scheduledTime = time;
+      }
+      payload.greeting = greeting;
+      if (price !== '') {
+        const priceNum = Number(price);
+        if (isNaN(priceNum)) {
+          global.alert('Price must be a number');
+          return;
+        }
+        payload.price = priceNum;
+      } else {
+        payload.price = null;
+      }
+      payload.lockedText = locked;
+      try {
+        const res = await global.fetch(
+          `/api/scheduledMessages/${this.currentMessage.id}`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          },
+        );
+        if (!res.ok) throw new Error('Failed to edit message');
+        this.hideEdit();
+        this.fetch();
+      } catch (err) {
+        global.console.error('Error editing message:', err);
+        global.alert('Error editing message');
+      }
+    },
+  };
 
-document.addEventListener('DOMContentLoaded', () => {
-  Queue.init();
-  Queue.fetch();
-  const refreshBtn = document.getElementById('refreshBtn');
-  if (refreshBtn) refreshBtn.addEventListener('click', () => Queue.fetch());
-  setInterval(() => Queue.fetch(), 60000);
-});
+  global.App = global.App || {};
+  global.App.Queue = Queue;
+
+  if (typeof module !== 'undefined') {
+    module.exports = Queue;
+  }
+
+  global.document.addEventListener('DOMContentLoaded', () => {
+    Queue.init();
+    Queue.fetch();
+    const refreshBtn = global.document.getElementById('refreshBtn');
+    if (refreshBtn) refreshBtn.addEventListener('click', () => Queue.fetch());
+    global.setInterval(() => Queue.fetch(), 60000);
+  });
+})(typeof window !== 'undefined' ? window : global);

--- a/public/results.js
+++ b/public/results.js
@@ -52,7 +52,7 @@
     sendResults = Array.isArray(arr) ? arr : [];
   }
 
-  const api = {
+  const Results = {
     clearStatusDots,
     downloadResults,
     addResult,
@@ -61,13 +61,10 @@
     setSendResults,
   };
 
+  global.App = global.App || {};
+  global.App.Results = Results;
+
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = api;
-  } else {
-    global.clearStatusDots = clearStatusDots;
-    global.downloadResults = downloadResults;
-    global.addResult = addResult;
-    global.resultsToCSV = resultsToCSV;
-    global.OFEMResults = api;
+    module.exports = Results;
   }
 })(typeof window !== 'undefined' ? window : global);


### PR DESCRIPTION
## Summary
- wrap client-side scripts in IIFEs and expose modules via a shared `App` namespace
- update HTML to call the new `App` methods for editor, history, queue, follow, results, and PPV features

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68956fa0e64c8321b81852247521bb0b