### PR TITLE
Clarify Parker names and add JSDoc comments

### DIFF
--- a/__tests__/scheduler.test.js
+++ b/__tests__/scheduler.test.js
@@ -86,7 +86,7 @@ test('recurring PPVs send once per fan per month across cycles', async () => {
 
   jest.useFakeTimers();
   const sendSpy = jest.fn().mockResolvedValue();
-  app._setSendPersonalizedMessage(sendSpy);
+  app._setSendMessageToFan(sendSpy);
   mockAxios.get.mockResolvedValue({ data: { accounts: [{ id: 'acc1' }] } });
   mockAxios.post.mockResolvedValue({ data: {} });
 

--- a/routes/fans.js
+++ b/routes/fans.js
@@ -380,6 +380,7 @@ $40,$41,$42,$43
     res.json({ inProgress: parkerUpdateInProgress });
   });
 
+  // Populate Parker names—friendly nicknames used in messages—for fans missing one
   router.post('/updateParkerNames', async (req, res) => {
     const missing = [];
     if (!process.env.OPENAI_API_KEY) missing.push('OPENAI_API_KEY');

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -6,7 +6,7 @@ module.exports = function ({
   ofApi,
   pool,
   sanitizeError,
-  sendPersonalizedMessage,
+  sendMessageToFan,
   getMissingEnvVars,
 }) {
   const router = express.Router();
@@ -78,7 +78,7 @@ module.exports = function ({
       let price = parseFloat(req.body.price);
       if (isNaN(price) || (mediaFiles.length === 0 && !lockedText)) price = 0;
 
-      await sendPersonalizedMessage(
+      await sendMessageToFan(
         fanId,
         greeting,
         body,


### PR DESCRIPTION
## Summary
- add JSDoc docs for rate-limited API wrappers and scheduling helpers
- rename sendPersonalizedMessage to sendMessageToFan for clearer intent
- document Parker name concept and deterministic fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689572a9b84c8321810c9b3c901c9fde