### PR TITLE
Handle OnlyFans auth errors

### DIFF
--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -82,6 +82,17 @@ beforeEach(async () => {
   mockAxios.post.mockReset();
 });
 
+test('returns 401 when OnlyFans API returns 401', async () => {
+  mockAxios.get
+    .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
+    .mockRejectedValueOnce({ response: { status: 401 } });
+
+  const res = await request(app).post('/api/refreshFans').expect(401);
+  expect(res.body).toEqual({
+    error: 'Invalid or expired OnlyFans API key.',
+  });
+});
+
 test('inserts and retrieves fan with new columns', async () => {
   const ts = 1691000000;
   const iso = new Date(ts * 1000).toISOString();


### PR DESCRIPTION
## Summary
- Rethrow OnlyFans 401/403 responses when paging fans to avoid partial data
- Surface invalid OnlyFans API key errors in `/api/refreshFans` with a 401
- Test `/api/refreshFans` responds 401 when OnlyFans returns 401

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68957f298d748321a249d7ee3d6da640