### PR TITLE
Remove unused catch parameters

### DIFF
--- a/db.js
+++ b/db.js
@@ -42,7 +42,7 @@ async function ensureDatabaseExists() {
   } finally {
     try {
       await appClient.end();
-    } catch (e) {}
+    } catch {}
   }
 
   // Database is missing. Attempt to connect to the default "postgres" DB and
@@ -85,7 +85,7 @@ async function ensureDatabaseExists() {
   } finally {
     try {
       await client.end();
-    } catch (e) {}
+    } catch {}
   }
 }
 
@@ -93,7 +93,7 @@ async function ensureDatabaseExists() {
 (async () => {
   try {
     await ensureDatabaseExists();
-  } catch (err) {
+  } catch {
     // Fail fast if database setup is incorrect
     process.exit(1);
   }

--- a/routes/ppv.js
+++ b/routes/ppv.js
@@ -295,7 +295,7 @@ module.exports = function ({
         let accountId;
         try {
           accountId = await getOFAccountId();
-        } catch (_) {
+        } catch {
           accountId = null;
         }
         if (accountId) {

--- a/setup-db.js
+++ b/setup-db.js
@@ -83,7 +83,7 @@ async function waitForPostgres(config, retries = 10) {
       await client.connect();
       await client.end();
       return true;
-    } catch (err) {
+    } catch {
       await new Promise((res) => setTimeout(res, 1000));
     }
   }
@@ -97,14 +97,14 @@ async function ensurePostgres(adminConfig) {
     await testClient.connect();
     await testClient.end();
     return true;
-  } catch (err) {
+  } catch {
     console.log(
       'PostgreSQL not reachable, attempting to start via docker compose...',
     );
     // First confirm docker is installed; otherwise the user needs to install or start Postgres manually.
     try {
       await execAsync('docker --version');
-    } catch (e) {
+    } catch {
       console.error(
         'Docker is not installed. Please install Docker Desktop or start PostgreSQL manually.',
       );


### PR DESCRIPTION
## Summary
- drop unused `catch` variables in database and setup scripts to prevent silent errors
- simplify PPV deletion error handling by removing unused catch binding

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895825cdd5c8321abca3a132791ca07