### PR TITLE
Expose OnlyFans auth errors during fan refresh

### DIFF
--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -93,6 +93,17 @@ test('returns 401 when OnlyFans API returns 401', async () => {
   });
 });
 
+test('returns OnlyFans error message when available on auth failures', async () => {
+  mockAxios.get
+    .mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } })
+    .mockRejectedValueOnce({
+      response: { status: 403, data: { error: 'Account suspended' } },
+    });
+
+  const res = await request(app).post('/api/refreshFans').expect(401);
+  expect(res.body).toEqual({ error: 'Account suspended' });
+});
+
 test('inserts and retrieves fan with new columns', async () => {
   const ts = 1691000000;
   const iso = new Date(ts * 1000).toISOString();

--- a/routes/fans.js
+++ b/routes/fans.js
@@ -371,9 +371,11 @@ $40,$41,$42,$43
           : 500);
 
       if (status === 401 || status === 403) {
-        return res
-          .status(401)
-          .json({ error: 'Invalid or expired OnlyFans API key.' });
+        const msg =
+          err.response?.data?.error ||
+          err.response?.data?.message ||
+          'Invalid or expired OnlyFans API key.';
+        return res.status(401).json({ error: msg });
       }
 
       const message =


### PR DESCRIPTION
## Summary
- Return upstream OnlyFans error messages when `/api/refreshFans` fails with auth errors
- Add test to ensure auth failures surface OnlyFans' message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689592ac1b4883218ec33818358a434e