### PR TITLE
Log OnlyFans error details

### DIFF
--- a/routes/messages.js
+++ b/routes/messages.js
@@ -131,19 +131,22 @@ module.exports = function ({
       if (err.code === 'FAN_NOT_ELIGIBLE') {
         return res.status(400).json({ error: err.message });
       }
+      const ofError = err.onlyfans_response?.body?.error;
       console.error(
         'Error sending message to fan:',
         err.response
           ? err.response.data || err.response.statusText
           : err.message,
+        ofError || '',
       );
       const status = err.status || err.response?.status;
-      const message =
+      let message =
         status === 429
           ? 'OnlyFans API rate limit exceeded. Please try again later.'
           : err.response
             ? err.response.statusText || err.response.data
             : err.message;
+      if (ofError) message += ` (OnlyFans error: ${ofError})`;
       res.status(status || 500).json({ error: message });
     }
   });


### PR DESCRIPTION
## Summary
- Log OnlyFans error message when sending a DM fails
- Append raw OnlyFans error to HTTP responses for easier debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966821ffe88321868c5cc33d0833f3