### PR TITLE
Validate non-empty message templates after substitution

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -290,3 +290,16 @@ test('returns 400 for fans that cannot receive messages', async () => {
     .expect(400);
   expect(mockAxios.post).not.toHaveBeenCalled();
 });
+
+test('returns 400 when template is empty after substitution', async () => {
+  await mockPool.query(
+    "INSERT INTO fans (id, parker_name, username, location, isSubscribed, canReceiveChatMessage) VALUES (1, '', '', '', TRUE, TRUE)",
+  );
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  const res = await request(app)
+    .post('/api/sendMessage')
+    .send({ userId: 1, greeting: '', body: '{parker_name}' });
+  expect(res.status).toBe(400);
+  expect(res.body).toEqual({ error: expect.stringContaining('empty') });
+  expect(mockAxios.post).not.toHaveBeenCalled();
+});

--- a/server.js
+++ b/server.js
@@ -294,6 +294,13 @@ let sendMessageToFan = async function (
   template = template.replace(/\{name\}|\[name\]|\{parker_name\}/g, parkerName);
   template = template.replace(/\{username\}/g, userName);
   template = template.replace(/\{location\}/g, userLocation);
+  if (template.trim().length === 0) {
+    const err = new Error(
+      'Message template empty after placeholder substitution; provide fallback text.',
+    );
+    err.status = 400;
+    throw err;
+  }
   const formatted = getEditorHtml(template);
   const mediaIds = Array.isArray(mediaFiles)
     ? mediaFiles.map(Number).filter(Number.isFinite)


### PR DESCRIPTION
## Summary
- Ensure `sendMessageToFan` rejects templates left empty after placeholder substitution
- Add regression test for empty template scenario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689669d84d208321b07728981c347e01