### PR TITLE
Add ability to send individual PPVs

### DIFF
--- a/migrate_add_ppv_sends.js
+++ b/migrate_add_ppv_sends.js
@@ -1,0 +1,34 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate_add_ppv_sends.js
+   Purpose: Create table for logging one-off PPV sends
+   Created: 2025-??-?? – v1.0
+*/
+
+const dotenv = require('dotenv');
+dotenv.config(); // Load environment variables for db.js
+
+const pool = require('./db');
+
+const createTableQuery = `
+CREATE TABLE IF NOT EXISTS ppv_sends (
+    id BIGSERIAL PRIMARY KEY,
+    ppv_id BIGINT REFERENCES ppv_sets(id) ON DELETE CASCADE,
+    fan_id BIGINT,
+    sent_at TIMESTAMP DEFAULT NOW()
+);
+`;
+
+(async () => {
+  try {
+    await pool.query(createTableQuery);
+    console.log("✅ 'ppv_sends' table created or already exists.");
+  } catch (err) {
+    console.error('Error running ppv_sends migration:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+    if (process.exitCode) process.exit(process.exitCode);
+  }
+})();
+
+/* End of File – Last modified 2025-??-?? */

--- a/migrate_all.js
+++ b/migrate_all.js
@@ -14,6 +14,7 @@ const scripts = [
   'migrate_add_ppv_tables.js',
   'migrate_add_ppv_schedule_fields.js',
   'migrate_add_ppv_message_field.js',
+  'migrate_add_ppv_sends.js',
 ];
 
 for (const script of scripts) {

--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -27,7 +27,7 @@
       const day = p.scheduleDay != null ? p.scheduleDay : 'None';
       const time = p.scheduleTime ? formatTime(p.scheduleTime) : 'None';
       const tr = global.document.createElement('tr');
-      tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.message || ''}</td><td>${p.price}</td><td>${day}</td><td>${time}</td><td><button class="btn btn-secondary" onclick="App.PPV.deletePpv(${p.id})">Delete</button></td>`;
+      tr.innerHTML = `<td>${p.ppv_number}</td><td>${p.message || ''}</td><td>${p.price}</td><td>${day}</td><td>${time}</td><td><button class="btn btn-primary" onclick="App.PPV.sendPpvPrompt(${p.id})">Send</button> <button class="btn btn-secondary" onclick="App.PPV.deletePpv(${p.id})">Delete</button></td>`;
       tbody.appendChild(tr);
     }
   }
@@ -204,6 +204,35 @@
     }
   }
 
+  async function sendPpv(id, fanId) {
+    try {
+      const res = await global.fetch(`/api/ppv/${id}/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fanId }),
+      });
+      const result = await res.json().catch(() => ({}));
+      if (res.ok) {
+        global.alert('PPV sent successfully');
+      } else {
+        global.alert(result.error || 'Failed to send PPV');
+      }
+    } catch (err) {
+      global.console.error('Error sending PPV:', err);
+    }
+  }
+
+  function sendPpvPrompt(id) {
+    const fanStr = global.prompt('Enter fan ID');
+    if (!fanStr) return;
+    const fanId = parseInt(fanStr, 10);
+    if (!Number.isInteger(fanId)) {
+      global.alert('Invalid fan ID');
+      return;
+    }
+    sendPpv(id, fanId);
+  }
+
   function init() {
     const loadBtn = global.document.getElementById('loadVaultBtn');
     if (loadBtn) loadBtn.addEventListener('click', loadVaultMedia);
@@ -223,6 +252,8 @@
     uploadMedia,
     savePpv,
     deletePpv,
+    sendPpv,
+    sendPpvPrompt,
     init,
   };
 

--- a/server.js
+++ b/server.js
@@ -349,6 +349,7 @@ const ppvRoutes = require('./routes/ppv')({
   ofApi,
   pool,
   sanitizeError,
+  sendMessageToFan,
 });
 const messagesRoutes = require('./routes/messages')({
   getOFAccountId,


### PR DESCRIPTION
## Summary
- add `POST /ppv/:id/send` to deliver a PPV to a specific fan and log the send
- surface "Send" action in PPV manager UI
- create `ppv_sends` table and include migration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896700bd0c88321893811b0d828dbb8