### PR TITLE
Show message when no fans to follow

### DIFF
--- a/__tests__/followFans.test.js
+++ b/__tests__/followFans.test.js
@@ -1,3 +1,4 @@
+const { JSDOM } = require('jsdom');
 const { newDb } = require('pg-mem');
 const mem = newDb();
 const pg = mem.adapters.createPg();
@@ -55,4 +56,25 @@ test('POST /api/fans/:id/follow calls OnlyFans API and updates DB', async () => 
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/users/1/follow');
   const dbRes = await pool.query('SELECT isSubscribed FROM fans WHERE id=1');
   expect(dbRes.rows[0].issubscribed).toBe(true);
+});
+
+test('renderTable displays a message when there are no fans to follow', async () => {
+  jest.resetModules();
+  const dom = new JSDOM(
+    '<table><tbody id="followTableBody"></tbody></table><div id="statusMsg"></div><button id="followBtn"></button>',
+  );
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const fetchMock = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: () => Promise.resolve({ fans: [] }) });
+  global.fetch = dom.window.fetch = fetchMock;
+  const alertMock = jest.fn();
+  global.alert = dom.window.alert = alertMock;
+  const { renderTable } = require('../public/follow');
+  renderTable();
+  await Promise.resolve();
+  expect(
+    dom.window.document.getElementById('statusMsg').textContent,
+  ).toMatch(/no fans to follow/i);
 });

--- a/public/follow.js
+++ b/public/follow.js
@@ -45,6 +45,13 @@
     });
     const btn = global.document.getElementById('followBtn');
     if (btn) btn.disabled = unfollowed.length === 0;
+    const statusMsg = global.document.getElementById('statusMsg');
+    if (statusMsg) {
+      statusMsg.textContent =
+        unfollowed.length === 0
+          ? 'No fans to follow. Try running /api/refreshFans.'
+          : '';
+    }
   }
 
   function setStatusDot(id, color) {


### PR DESCRIPTION
## Summary
- Display a helpful notice on the follow page when there are no unfollowed fans, recommending `/api/refreshFans`.
- Add regression test ensuring the no-fans message appears when the list is empty.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966fc5ba78832198c2fd98d31104d3