### PR TITLE
feat: clarify no-fans message

### DIFF
--- a/__tests__/followFans.test.js
+++ b/__tests__/followFans.test.js
@@ -74,7 +74,7 @@ test('renderTable displays a message when there are no fans to follow', async ()
   const { renderTable } = require('../public/follow');
   renderTable();
   await Promise.resolve();
-  expect(
-    dom.window.document.getElementById('statusMsg').textContent,
-  ).toMatch(/no fans to follow/i);
+  const msg = dom.window.document.getElementById('statusMsg').textContent;
+  expect(msg).toMatch(/no fans to follow/i);
+  expect(msg).toMatch(/\/api\/refreshFans/);
 });

--- a/public/follow.js
+++ b/public/follow.js
@@ -49,7 +49,7 @@
     if (statusMsg) {
       statusMsg.textContent =
         unfollowed.length === 0
-          ? 'No fans to follow. Try running /api/refreshFans.'
+          ? 'No fans to follow. Please run /api/refreshFans to sync.'
           : '';
     }
   }


### PR DESCRIPTION
## Summary
- clarify message when there are no fans to follow
- add test ensuring the refresh hint appears

## Testing
- `npm test __tests__/followFans.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6896728340788321a5760f8fddb54f5c