### PR TITLE
feat: dockerize application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Node.js 22 LTS alpine image
+FROM node:22-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install --production
+
+# Bundle app source
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Run the application
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ The `/api/status` endpoint reports whether each variable has been configured.
    server. On other systems run `./predeploy.command` or `node migrate_all.js`
    before `npm start` to ensure the database schema is current.
 
+## Docker
+
+A `Dockerfile` and `docker-compose.yml` are included for containerised
+development.
+
+1. **Build the image**
+
+   ```bash
+   docker build -t ofem-app .
+   ```
+
+2. **Run the app and database**
+
+   Ensure `ONLYFANS_API_KEY` and `OPENAI_API_KEY` are set in your environment
+   and then start the services:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The server will be available at <http://localhost:3000>.
+
 ## Fan Fields Migration and New Columns
 
 Run the migration scripts below to ensure your database includes all of the latest fan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,21 @@
 
 version: '3.8'
 services:
+  app:
+    build: .
+    restart: unless-stopped
+    depends_on:
+      - db
+    environment:
+      DB_NAME: ofdb
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: db
+      DB_PORT: 5432
+      ONLYFANS_API_KEY: ${ONLYFANS_API_KEY}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    ports:
+      - "3000:3000"
   db:
     image: postgres:15-alpine
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Dockerfile to run Node app
- add `app` service to docker-compose with database and API env vars
- document Docker build and run steps in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967f13844c8321b8cfe2cfd60e2122