### PR TITLE
docs: clarify minimum Node.js requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Required Tools
 
-- Node.js 22 LTS
+- Node.js 22 LTS (>=22.0.0)
 - PostgreSQL
 - OnlyFans API key
 - OpenAI API key

--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ nicknames.
 
 ## Prerequisites
 
-- Node.js 22 LTS (v22.18.0)
+- Node.js 22 LTS (>=22.0.0)
 - PostgreSQL database accessible via `DATABASE_URL`
 - OnlyFans API key (required)
 - OpenAI API key
+
+> We recommend using a Node version manager like [nvm](https://github.com/nvm-sh/nvm) to install and switch between Node.js versions.
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-exclude": "^7.0.1"
   },
   "engines": {
-    "node": ">=22.18.0"
+    "node": ">=22.0.0"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
## Summary
- clarify Node.js 22 LTS as the minimum supported version
- document node version management with nvm
- align package.json engines field with Node 22

## Testing
- `npm test --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_689686a0bf048321b55616509cffd133