### PR TITLE
Add macOS command scripts and setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ personalised message to everyone in one pass. It uses the official OnlyFans API 
 fetch the fan list and send direct messages and an OpenAI GPT model (default `gpt-4o-mini`) to generate friendly
 nicknames.
 
+> **macOS users:** This repo includes several `.command` files (e.g., `install.command`, `setup-env.command`, `setup-db.command`, `start.command`) so non-technical Mac users can set up and run OFEM by double-clicking. **Never remove these `.command` files without the project owner's explicit approval.** For a guided walkthrough, open `predeploy.html` and follow the on-screen buttons.
+
 ## Features
 
 - **Update Fan List** – Fetches all subscribers and followings and stores them in the

--- a/addtodatabase.command
+++ b/addtodatabase.command
@@ -1,0 +1,27 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Migration Runner
+# Usage: Double-click this file or run in Terminal to apply non-destructive migrations.
+# Created: 2025-08-05 – v1.0
+# Runs all database migrations via migrate_all.js.
+
+set -e
+cd "$(dirname "$0")"
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but not installed. Please install Node.js." >&2
+  exit 1
+fi
+
+# Ensure required Node modules for database tasks are installed
+missing=false
+for mod in pg dotenv; do
+  if [ ! -d "node_modules/$mod" ]; then
+    missing=true
+    break
+  fi
+done
+if [ "$missing" = true ]; then
+  echo "Installing Node dependencies..."
+  npm install >/dev/null
+fi
+
+node migrate_all.js

--- a/install-docker.command
+++ b/install-docker.command
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# OnlyFans Express Messenger (OFEM) - Docker Install Script
+# Installs Docker Desktop using Homebrew.
+set -e
+cd "$(dirname "$0")"
+
+OS=$(uname)
+if [[ "$OS" != "Darwin" ]]; then
+  echo "Unsupported OS: $OS"
+  exit 1
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found. Please install Homebrew from https://brew.sh"
+  exit 1
+fi
+
+echo "Installing Docker Desktop via Homebrew..."
+brew install --cask docker
+open -a Docker || open /Applications/Docker.app
+echo "Docker Desktop installed."

--- a/install-node.command
+++ b/install-node.command
@@ -1,0 +1,49 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Node.js Install Script
+# Downloads a specific LTS version of Node.js and installs project dependencies.
+set -e
+cd "$(dirname "$0")"
+
+# Update NODE_VERSION when upgrading Node.js.
+# See https://nodejs.org/en/about/releases/ for latest LTS releases.
+# Currently targeting Node.js 22 LTS (Jod).
+NODE_VERSION="v22.18.0"
+NODE_MAJOR="${NODE_VERSION#v}"
+NODE_MAJOR="${NODE_MAJOR%%.*}"
+
+# Skip installation if desired version is already installed.
+if command -v node >/dev/null 2>&1 && [ "$(node -v)" = "$NODE_VERSION" ]; then
+  echo "✅ Node.js $NODE_VERSION already installed; skipping download."
+else
+  if command -v brew >/dev/null 2>&1; then
+    echo "🍺 Homebrew detected; installing Node.js ${NODE_VERSION} via Homebrew..."
+    if ! brew ls --versions "node@${NODE_MAJOR}" >/dev/null 2>&1; then
+      brew install "node@${NODE_MAJOR}"
+    fi
+    if ! brew link "node@${NODE_MAJOR}"; then
+      brew link --overwrite --force "node@${NODE_MAJOR}"
+    fi
+  else
+    NODE_PKG="node-${NODE_VERSION}.pkg"
+    NODE_URL="https://nodejs.org/dist/${NODE_VERSION}/${NODE_PKG}"
+
+    echo "📦 Downloading Node.js ${NODE_VERSION} (LTS)..."
+    if curl -fsSL "$NODE_URL" -o "$NODE_PKG"; then
+      echo "⚙️ Installing Node.js..."
+      if command -v installer >/dev/null 2>&1; then
+        sudo installer -pkg "$NODE_PKG" -target /
+        rm "$NODE_PKG"
+      else
+        echo "installer command not found; skipping Node.js installation"
+      fi
+    else
+      echo "⚠️ Unable to download Node.js ${NODE_VERSION}."
+      echo "   Please manually download the LTS version from https://nodejs.org/."
+    fi
+  fi
+fi
+
+echo "📚 Installing npm packages..."
+npm install
+
+echo "✅ Node.js and packages installed successfully."

--- a/install.command
+++ b/install.command
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Exit on first error
+set -e
+# OnlyFans Express Messenger (OFEM) - Install Script
+# Usage: Double-click this file (on macOS) or run it in Terminal to set up the project.
+# Created: 2025-08-02 – v1.0
+
+cd "$(dirname "$0")"
+echo "🔧 Installing Node.js dependencies (this may take a moment)..."
+npm install
+
+if [ -f .env ]; then
+  echo "🐘 Running database migrations..."
+  if node migrate.js; then
+    echo "Database is ready."
+  else
+    echo "Skipping migrations (database not yet configured)."
+  fi
+fi
+
+echo "✅ Installation complete!"
+echo "-------------------------------------------------"
+echo "Next steps:"
+echo "1. If you haven't created the database yet, open predeploy.html and click 'Set up new database'."
+echo "2. Start the server with: ./start.command"
+echo ""
+echo "Happy messaging! 😃"
+
+# End of File – Last modified 2025-08-02

--- a/predeploy.html
+++ b/predeploy.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Getting Started with OFEM</title>
+</head>
+<body>
+<h1>Getting Started with OFEM</h1>
+<p>Follow these simple steps on a Mac to run OFEM. No programming knowledge required.</p>
+
+<h2>Download and Unzip</h2>
+<ol>
+<li>Download the project ZIP file.</li>
+<li>Open your Downloads folder and double‑click the ZIP to create the OFEM folder.</li>
+</ol>
+
+<h2>Allow Scripts to Run</h2>
+<p>Click the button below to remove the quarantine flag from all .command files (install, setup-env, setup-db, start, etc.).</p>
+<p><a href="remove-quarantine.command">Allow command files</a></p>
+<p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>remove-quarantine.command</code> manually.</p>
+
+<h2>Install Requirements</h2>
+<p>Click the button below to install Node.js (LTS) in this folder and download all required npm packages.</p>
+<p><a href="install-node.command">Install Node at Folder</a></p>
+<p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>install-node.command</code> manually.</p>
+<p>You may be asked for your macOS password to complete the installation.</p>
+
+<p>Click the button below to install Docker Desktop using Homebrew.</p>
+<p><a href="install-docker.command">Install Docker</a></p>
+<p>This opens Terminal in the OFEM folder and runs <code>brew install --cask docker</code>. If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>install-docker.command</code> manually.</p>
+<p>If you already have a local PostgreSQL server running you can skip Docker, but the setup wizard uses Docker by default.</p>
+
+<p>Once Node and Docker are installed, run the project installer below to install all Node dependencies.</p>
+<p><a href="install.command">Run installer</a></p>
+<p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>install.command</code> manually.</p>
+
+<h2>Configure API Keys and Database (optional)</h2>
+<p>Click the button below to enter your OnlyFans and OpenAI API keys. The script also accepts credentials for an existing PostgreSQL database; leave these fields blank to create a new database later.</p>
+<p><a href="setup-env.command">Configure API keys and DB</a></p>
+<p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>setup-env.command</code> manually.</p>
+
+<h2>Create the Database</h2>
+<p>If you supplied database credentials above, you can skip this step. Otherwise, click the button below to create a new database. A wizard opens in Terminal, creates a database with a random name, user, and password, then updates your <code>.env</code> file automatically.</p>
+<p><a href="setup-db.command">Set up new database</a></p>
+<p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double‑click <code>setup-db.command</code> manually.</p>
+<p>Leave the Terminal window open until it shows “Database setup complete!”. If it reports an error, install Docker Desktop or start PostgreSQL manually and then retry. To capture detailed logs, run <code>bash setup-db.command 2>&1 | tee setup-db.log</code> and send the resulting setup-db.log file for support.</p>
+<p>After running <code>setup-env.command</code> and <code>setup-db.command</code>, the initial database setup is complete.</p>
+
+<h2>Upgrade Existing Database (optional)</h2>
+<p>Existing installs must run <code>addtodatabase.command</code> whenever new migrations are introduced to keep the schema up to date. Fresh installations can skip this until a migration is added.</p>
+<p><a href="addtodatabase.command">Run migrations</a></p>
+<p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>addtodatabase.command</code> manually.</p>
+<p>This command is required each time new migrations are added to the project.</p>
+
+<h2>Run the App</h2>
+<p>Double‑click <code>start.command</code> to launch the server.</p>
+
+<h2>Open the Dashboard</h2>
+<p>When Terminal shows “OFEM server listening on http://localhost:3000” (or another port), open a web browser. If port 3000 is in use, edit your <code>.env</code> file and change the PORT value, then restart <code>start.command</code>.</p>
+<p>Visit <a href="http://localhost:3000">http://localhost:3000</a> (replace 3000 with your chosen port).</p>
+<p>The app is now ready. Use the dashboard buttons to update fan names and send messages.</p>
+</body>
+</html>

--- a/remove-quarantine.command
+++ b/remove-quarantine.command
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Remove the macOS quarantine attribute from command files
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+for f in "$DIR"/*.command; do
+  xattr -d com.apple.quarantine "$f" 2>/dev/null || true
+done
+
+echo "Quarantine flags removed from command files."

--- a/setup-db.command
+++ b/setup-db.command
@@ -1,0 +1,33 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Database Setup Wizard
+# Usage: Double-click this file (on macOS) or run it in Terminal to create a new database.
+# Created: 2025-08-02 – v1.0
+# Includes migrations for scheduled messages and PPV tables.
+
+set -e
+cd "$(dirname "$0")"
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but not installed. Please install Node.js." >&2
+  exit 1
+fi
+
+# Ensure required Node modules for database tasks are installed
+missing=false
+for mod in pg dotenv; do
+  if [ ! -d "node_modules/$mod" ]; then
+    missing=true
+    break
+  fi
+done
+if [ "$missing" = true ]; then
+  echo "Installing Node dependencies..."
+  npm install >/dev/null
+fi
+
+node setup-db.js
+node migrate.js
+node migrate_add_fan_fields.js
+node migrate_messages.js
+node migrate_scheduled_messages.js
+node migrate_add_ppv_tables.js
+node migrate_add_ppv_schedule_fields.js

--- a/setup-env.command
+++ b/setup-env.command
@@ -1,0 +1,8 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Environment Setup Wizard
+# Usage: Double-click this file (on macOS) or run it in Terminal to create/update .env with API keys.
+# Created: 2025-08-05 – v1.0
+
+set -e
+cd "$(dirname "$0")"
+node setup-env.js

--- a/start.command
+++ b/start.command
@@ -1,0 +1,18 @@
+#!/bin/bash
+# OnlyFans Express Messenger (OFEM) - Start Script
+# Usage: Double-click this file (on macOS) or run it in Terminal to start the server.
+# Created: 2025-08-02 – v1.0
+
+set -e
+cd "$(dirname "$0")"
+echo "Starting OnlyFans Express Messenger..."
+echo "Press Ctrl+C to stop the server."
+
+# Install dependencies if pg (PostgreSQL client) is missing
+if ! node -e "require('pg')" >/dev/null 2>&1; then
+  echo "Installing npm packages..."
+  npm install
+fi
+
+node migrate_all.js
+npm start


### PR DESCRIPTION
## Summary
- Add suite of macOS `.command` helpers for quarantine removal, Node.js/Docker installation, environment/database setup, migrations and server startup
- Provide `predeploy.html` with button-based walkthrough for non-technical Mac users
- Update README with warning not to remove `.command` files and reference the new guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68969c46d2a88321b1da615e2f139b00