### PR TITLE
Add refresh fans sync button on follow page

### DIFF
--- a/__tests__/followFans.test.js
+++ b/__tests__/followFans.test.js
@@ -76,5 +76,5 @@ test('renderTable displays a message when there are no fans to follow', async ()
   await Promise.resolve();
   const msg = dom.window.document.getElementById('statusMsg').textContent;
   expect(msg).toMatch(/no fans to follow/i);
-  expect(msg).toMatch(/\/api\/refreshFans/);
+  expect(msg).toMatch(/refresh fans/i);
 });

--- a/public/follow.html
+++ b/public/follow.html
@@ -21,6 +21,7 @@
     <h1>Follow Fans and Followers</h1>
     <p>Click "Follow Now" to follow all unfollowed fans and followers.</p>
     <button id="followBtn" class="btn btn-primary">Follow Now</button>
+    <button id="refreshBtn" class="btn btn-secondary">Refresh Fans</button>
     <div id="statusMsg" class="status-msg"></div>
     <table id="followTable" class="form-table">
       <thead>

--- a/public/follow.js
+++ b/public/follow.js
@@ -49,7 +49,7 @@
     if (statusMsg) {
       statusMsg.textContent =
         unfollowed.length === 0
-          ? 'No fans to follow. Please run /api/refreshFans to sync.'
+          ? "No fans to follow. Click 'Refresh Fans' to sync."
           : '';
     }
   }
@@ -104,9 +104,26 @@
     };
   }
 
+  async function refreshFans() {
+    const btn = global.document.getElementById('refreshBtn');
+    if (btn) btn.disabled = true;
+    try {
+      const res = await global.fetch('/api/refreshFans', { method: 'POST' });
+      if (!res.ok) throw new Error('Failed to refresh fans');
+      await loadUnfollowed();
+    } catch (err) {
+      global.console.error('Error refreshing fans:', err);
+      global.alert('Failed to refresh fans');
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
   function init() {
     const btn = global.document.getElementById('followBtn');
     if (btn) btn.addEventListener('click', followAll);
+    const refreshBtn = global.document.getElementById('refreshBtn');
+    if (refreshBtn) refreshBtn.addEventListener('click', refreshFans);
     loadUnfollowed();
   }
 
@@ -115,6 +132,7 @@
     renderTable,
     setStatusDot,
     followAll,
+    refreshFans,
     init,
   };
 


### PR DESCRIPTION
## Summary
- add "Refresh Fans" button to follow page and hook it to `/api/refreshFans`
- update follow page script to refresh list and adjust empty-state message
- adjust followFans test for new wording

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b00bc4ac8321bf33d7bcff9580ea