### PR TITLE
feat: track vault media stats

### DIFF
--- a/__tests__/vaultMedia.test.js
+++ b/__tests__/vaultMedia.test.js
@@ -16,13 +16,40 @@ beforeAll(() => {
 beforeEach(() => {
   mockAxios.get.mockReset();
   mockAxios.post.mockReset();
+  mockPool.query.mockReset();
 });
 
-test('GET /api/vault-media retrieves all pages', async () => {
+test('GET /api/vault-media syncs and returns stored media', async () => {
   mockAxios.get
     .mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } })
-    .mockResolvedValueOnce({ data: { media: [{ id: 'm1' }, { id: 'm2' }] } })
+    .mockResolvedValueOnce({
+      data: { media: [{ id: 'm1', likes: 1 }, { id: 'm2', likes: 2 }] },
+    })
     .mockResolvedValueOnce({ data: { media: [] } });
+
+  mockPool.query
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'm1',
+          likes: 1,
+          tips: null,
+          thumb_url: null,
+          preview_url: null,
+          created_at: null,
+        },
+        {
+          id: 'm2',
+          likes: 2,
+          tips: null,
+          thumb_url: null,
+          preview_url: null,
+          created_at: null,
+        },
+      ],
+    });
 
   const res = await request(app).get('/api/vault-media').expect(200);
 
@@ -32,13 +59,36 @@ test('GET /api/vault-media retrieves all pages', async () => {
   expect(mockAxios.get).toHaveBeenNthCalledWith(3, '/acc1/media/vault', {
     params: { limit: 100, offset: 100 },
   });
-  expect(res.body).toEqual([{ id: 'm1' }, { id: 'm2' }]);
+  expect(mockPool.query).toHaveBeenCalledTimes(3);
+  expect(mockPool.query).toHaveBeenNthCalledWith(
+    3,
+    'SELECT id, likes, tips, thumb_url, preview_url, created_at FROM vault_media ORDER BY id',
+  );
+  expect(res.body).toEqual([
+    {
+      id: 'm1',
+      likes: 1,
+      tips: null,
+      thumb_url: null,
+      preview_url: null,
+      created_at: null,
+    },
+    {
+      id: 'm2',
+      likes: 2,
+      tips: null,
+      thumb_url: null,
+      preview_url: null,
+      created_at: null,
+    },
+  ]);
 });
 
 test('GET /api/vault-media handles errors', async () => {
   mockAxios.get.mockRejectedValue(new Error('fail'));
   const res = await request(app).get('/api/vault-media').expect(500);
   expect(res.body).toEqual({ error: 'Failed to fetch vault media' });
+  expect(mockPool.query).not.toHaveBeenCalled();
 });
 
 test('POST /api/vault-media uploads files', async () => {

--- a/migrate_add_vault_media.js
+++ b/migrate_add_vault_media.js
@@ -1,0 +1,46 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate_add_vault_media.js
+   Purpose: Create table for storing vault media metadata
+   Created: 2025-??-?? – v1.0
+*/
+
+const dotenv = require('dotenv');
+dotenv.config(); // Load environment variables for db.js
+
+const pool = require('./db');
+
+const createTableQuery = `
+CREATE TABLE IF NOT EXISTS vault_media (
+    id BIGINT PRIMARY KEY,
+    likes INTEGER,
+    tips NUMERIC,
+    thumb_url TEXT,
+    preview_url TEXT,
+    created_at TIMESTAMP
+);
+`;
+
+const alterTableQuery = `
+ALTER TABLE vault_media
+    ADD COLUMN IF NOT EXISTS likes INTEGER,
+    ADD COLUMN IF NOT EXISTS tips NUMERIC,
+    ADD COLUMN IF NOT EXISTS thumb_url TEXT,
+    ADD COLUMN IF NOT EXISTS preview_url TEXT,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP;
+`;
+
+(async () => {
+  try {
+    await pool.query(createTableQuery);
+    await pool.query(alterTableQuery);
+    console.log("✅ 'vault_media' table created or already exists.");
+  } catch (err) {
+    console.error('Error running vault_media migration:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+    if (process.exitCode) process.exit(process.exitCode);
+  }
+})();
+
+/* End of File – Last modified 2025-??-?? */

--- a/migrate_all.js
+++ b/migrate_all.js
@@ -16,6 +16,7 @@ const scripts = [
   // PPV-related migrations
   'migrate_add_ppv_message_field.js',
   'migrate_add_ppv_sends.js',
+  'migrate_add_vault_media.js',
 ];
 
 for (const script of scripts) {


### PR DESCRIPTION
## Summary
- add `vault_media` table migration and include in migration runner
- sync OnlyFans vault media into the database and serve stored likes/tips from `/api/vault-media`
- cover new behavior with updated tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896ef6edc6083219745bfc59ba391ba