### PR TITLE
feat: add vault list routes and migrations

### DIFF
--- a/migrate_add_vault_lists.js
+++ b/migrate_add_vault_lists.js
@@ -1,0 +1,56 @@
+/* OnlyFans Express Messenger (OFEM)
+   File: migrate_add_vault_lists.js
+   Purpose: Create tables for vault lists and media relationships
+   Created: 2025-??-?? – v1.0
+*/
+
+const dotenv = require('dotenv');
+dotenv.config(); // Load environment variables for db.js
+
+const pool = require('./db');
+
+const createVaultListsTable = `
+CREATE TABLE IF NOT EXISTS vault_lists (
+    id BIGINT PRIMARY KEY,
+    name TEXT,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+`;
+
+const createVaultListMediaTable = `
+CREATE TABLE IF NOT EXISTS vault_list_media (
+    list_id BIGINT REFERENCES vault_lists(id) ON DELETE CASCADE,
+    media_id BIGINT,
+    PRIMARY KEY (list_id, media_id)
+);
+`;
+
+const alterVaultListsTable = `
+ALTER TABLE vault_lists
+    ADD COLUMN IF NOT EXISTS name TEXT,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT NOW();
+`;
+
+const alterVaultListMediaTable = `
+ALTER TABLE vault_list_media
+    ADD COLUMN IF NOT EXISTS list_id BIGINT REFERENCES vault_lists(id) ON DELETE CASCADE,
+    ADD COLUMN IF NOT EXISTS media_id BIGINT;
+`;
+
+(async () => {
+  try {
+    await pool.query(createVaultListsTable);
+    await pool.query(createVaultListMediaTable);
+    await pool.query(alterVaultListsTable);
+    await pool.query(alterVaultListMediaTable);
+    console.log("✅ 'vault_lists' and 'vault_list_media' tables created.");
+  } catch (err) {
+    console.error('Error running vault lists migration:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+    if (process.exitCode) process.exit(process.exitCode);
+  }
+})();
+
+/* End of File – Last modified 2025-??-?? */

--- a/migrate_all.js
+++ b/migrate_all.js
@@ -11,6 +11,7 @@ const scripts = [
   'migrate_add_fan_fields.js',
   'migrate_messages.js',
   'migrate_scheduled_messages.js',
+  'migrate_add_vault_lists.js',
   'migrate_add_ppv_tables.js',
   'migrate_add_ppv_schedule_fields.js',
   // PPV-related migrations

--- a/routes/vaultLists.js
+++ b/routes/vaultLists.js
@@ -1,0 +1,234 @@
+const express = require('express');
+
+module.exports = function ({
+  getOFAccountId,
+  ofApiRequest,
+  ofApi,
+  pool,
+  sanitizeError,
+}) {
+  const router = express.Router();
+
+  router.get('/vault-lists', async (req, res) => {
+    try {
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      const resp = await ofApiRequest(() =>
+        ofApi.get(`/${accountId}/media/vault/lists`),
+      );
+      const lists =
+        resp.data?.list ||
+        resp.data?.lists ||
+        resp.data?.data?.list ||
+        resp.data?.data?.lists ||
+        resp.data;
+      if (Array.isArray(lists)) {
+        for (const l of lists) {
+          const id = l.id;
+          const name = l.name || null;
+          if (id != null) {
+            await pool.query(
+              'INSERT INTO vault_lists (id, name) VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name',
+              [id, name],
+            );
+          }
+        }
+      }
+      res.json(lists);
+    } catch (err) {
+      console.error('Error fetching vault lists:', sanitizeError(err));
+      const status = err.message.includes('OnlyFans account') ? 400 : 500;
+      res.status(status).json({
+        error:
+          status === 400 ? err.message : 'Failed to fetch vault lists',
+      });
+    }
+  });
+
+  router.post('/vault-lists', async (req, res) => {
+    try {
+      const name = req.body?.name;
+      if (typeof name !== 'string' || !name.trim()) {
+        return res.status(400).json({ error: 'name required' });
+      }
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      const resp = await ofApiRequest(() =>
+        ofApi.post(`/${accountId}/media/vault/lists`, { name }),
+      );
+      const list = resp.data?.list || resp.data;
+      const id = list.id;
+      await pool.query(
+        'INSERT INTO vault_lists (id, name) VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name',
+        [id, name],
+      );
+      res.json(list);
+    } catch (err) {
+      console.error('Error creating vault list:', sanitizeError(err));
+      res.status(500).json({ error: 'Failed to create vault list' });
+    }
+  });
+
+  router.get('/vault-lists/:id', async (req, res) => {
+    try {
+      const id = req.params.id;
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      const resp = await ofApiRequest(() =>
+        ofApi.get(`/${accountId}/media/vault/lists/${id}`),
+      );
+      const list = resp.data?.list || resp.data;
+      const name = list.name || null;
+      await pool.query(
+        'INSERT INTO vault_lists (id, name) VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name',
+        [id, name],
+      );
+      const media =
+        list.media_ids ||
+        list.media?.map((m) => m.id) ||
+        list.media ||
+        [];
+      if (Array.isArray(media)) {
+        for (const mediaId of media) {
+          const mId = typeof mediaId === 'object' ? mediaId.id : mediaId;
+          if (mId != null) {
+            await pool.query(
+              'INSERT INTO vault_list_media (list_id, media_id) VALUES ($1,$2) ON CONFLICT DO NOTHING',
+              [id, mId],
+            );
+          }
+        }
+      }
+      res.json(list);
+    } catch (err) {
+      console.error('Error fetching vault list:', sanitizeError(err));
+      res.status(500).json({ error: 'Failed to fetch vault list' });
+    }
+  });
+
+  router.put('/vault-lists/:id', async (req, res) => {
+    try {
+      const id = req.params.id;
+      const name = req.body?.name;
+      if (typeof name !== 'string' || !name.trim()) {
+        return res.status(400).json({ error: 'name required' });
+      }
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      const resp = await ofApiRequest(() =>
+        ofApi.put(`/${accountId}/media/vault/lists/${id}`, { name }),
+      );
+      await pool.query(
+        'INSERT INTO vault_lists (id, name) VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name',
+        [id, name],
+      );
+      res.json(resp.data);
+    } catch (err) {
+      console.error('Error updating vault list:', sanitizeError(err));
+      res.status(500).json({ error: 'Failed to update vault list' });
+    }
+  });
+
+  router.delete('/vault-lists/:id', async (req, res) => {
+    try {
+      const id = req.params.id;
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      await ofApiRequest(() =>
+        ofApi.delete(`/${accountId}/media/vault/lists/${id}`),
+      );
+      await pool.query('DELETE FROM vault_lists WHERE id=$1', [id]);
+      await pool.query('DELETE FROM vault_list_media WHERE list_id=$1', [id]);
+      res.json({ success: true });
+    } catch (err) {
+      console.error('Error deleting vault list:', sanitizeError(err));
+      res.status(500).json({ error: 'Failed to delete vault list' });
+    }
+  });
+
+  router.post('/vault-lists/:id/media', async (req, res) => {
+    try {
+      const id = req.params.id;
+      const mediaIds = Array.isArray(req.body?.media_ids)
+        ? req.body.media_ids.map(Number).filter(Number.isFinite)
+        : [];
+      if (mediaIds.length === 0) {
+        return res.status(400).json({ error: 'media_ids required' });
+      }
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      const resp = await ofApiRequest(() =>
+        ofApi.post(`/${accountId}/media/vault/lists/${id}/media`, {
+          media_ids: mediaIds,
+        }),
+      );
+      for (const mediaId of mediaIds) {
+        await pool.query(
+          'INSERT INTO vault_list_media (list_id, media_id) VALUES ($1,$2) ON CONFLICT DO NOTHING',
+          [id, mediaId],
+        );
+      }
+      res.json(resp.data);
+    } catch (err) {
+      console.error('Error adding media to vault list:', sanitizeError(err));
+      res.status(500).json({ error: 'Failed to add media to vault list' });
+    }
+  });
+
+  router.delete('/vault-lists/:id/media', async (req, res) => {
+    try {
+      const id = req.params.id;
+      const mediaIds = Array.isArray(req.body?.media_ids)
+        ? req.body.media_ids.map(Number).filter(Number.isFinite)
+        : [];
+      if (mediaIds.length === 0) {
+        return res.status(400).json({ error: 'media_ids required' });
+      }
+      let accountId;
+      try {
+        accountId = await getOFAccountId();
+      } catch (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      const resp = await ofApiRequest(() =>
+        ofApi.delete(`/${accountId}/media/vault/lists/${id}/media`, {
+          data: { media_ids: mediaIds },
+        }),
+      );
+      await pool.query(
+        'DELETE FROM vault_list_media WHERE list_id=$1 AND media_id = ANY($2::bigint[])',
+        [id, mediaIds],
+      );
+      res.json(resp.data);
+    } catch (err) {
+      console.error('Error removing media from vault list:', sanitizeError(err));
+      res.status(500).json({ error: 'Failed to remove media from vault list' });
+    }
+  });
+
+  return router;
+};

--- a/server.js
+++ b/server.js
@@ -351,6 +351,13 @@ const ppvRoutes = require('./routes/ppv')({
   sanitizeError,
   sendMessageToFan,
 });
+const vaultListsRoutes = require('./routes/vaultLists')({
+  getOFAccountId,
+  ofApiRequest,
+  ofApi,
+  pool,
+  sanitizeError,
+});
 const messagesRoutes = require('./routes/messages')({
   getOFAccountId,
   ofApiRequest,
@@ -362,6 +369,7 @@ const messagesRoutes = require('./routes/messages')({
 });
 app.use('/api', fansRoutes);
 app.use('/api', ppvRoutes);
+app.use('/api', vaultListsRoutes);
 app.use('/api', messagesRoutes);
 
 // System status endpoint


### PR DESCRIPTION
## Summary
- add `routes/vaultLists.js` for managing OnlyFans vault lists and associated media
- log vault list and media relationships in new `vault_lists` and `vault_list_media` tables
- wire vault list routes into server and migration runner

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f1cd28988321b1f8f09ec86ffa69