### PR TITLE
feat: support vault lists in PPV manager

### DIFF
--- a/public/ppv.html
+++ b/public/ppv.html
@@ -52,6 +52,15 @@
             class="form-input w-80"
         /></label>
       </div>
+      <div class="mb-8">
+        <label
+          >Vault List:
+          <select id="vaultListSelect" class="form-input"></select>
+        </label>
+        <button id="createVaultListBtn" type="button" class="btn btn-secondary">
+          Create List
+        </button>
+      </div>
       <fieldset class="schedule-section mb-8">
         <legend>Scheduling</legend>
         <label


### PR DESCRIPTION
## Summary
- add vault list dropdown and creation controls to PPV manager
- render vault lists and media stats including icons, likes, tips
- associate selected vault list in PPV requests and preview labels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f3b326188321adf1bdbe7b5602ec