### PR TITLE
Add vault media deletion route and UI

### DIFF
--- a/__tests__/vaultMedia.test.js
+++ b/__tests__/vaultMedia.test.js
@@ -16,6 +16,8 @@ beforeAll(() => {
 beforeEach(() => {
   mockAxios.get.mockReset();
   mockAxios.post.mockReset();
+  mockAxios.delete.mockReset();
+  mockPool.query.mockReset();
 });
 
 test('GET /api/vault-media retrieves all pages', async () => {
@@ -56,4 +58,24 @@ test('POST /api/vault-media uploads files', async () => {
     expect.objectContaining({ headers: expect.any(Object) }),
   );
   expect(res.body).toEqual({ mediaIds: ['m1'] });
+});
+
+test('DELETE /api/vault-media/:id removes media', async () => {
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.delete.mockResolvedValueOnce({ data: {} });
+
+  const res = await request(app)
+    .delete('/api/vault-media/123')
+    .expect(200);
+
+  expect(mockAxios.delete).toHaveBeenCalledWith('/acc1/media/vault/123');
+  expect(mockPool.query).toHaveBeenCalledWith(
+    'DELETE FROM vault_media WHERE id=$1',
+    [123],
+  );
+  expect(mockPool.query).toHaveBeenCalledWith(
+    'DELETE FROM vault_list_media WHERE media_id=$1',
+    [123],
+  );
+  expect(res.body).toEqual({ success: true });
 });

--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -145,10 +145,33 @@
 
         linkPreviewInclude(mediaCb, previewCb, accessSpan);
 
+        const delBtn = global.document.createElement('button');
+        delBtn.className = 'btn btn-sm btn-danger delete-media-btn';
+        delBtn.textContent = 'Delete';
+        delBtn.addEventListener('click', () => deleteVaultMedia(m.id));
+        div.appendChild(delBtn);
+
         container.appendChild(div);
       }
     } catch (err) {
       global.console.error('Error loading vault media:', err);
+    }
+  }
+
+  async function deleteVaultMedia(id) {
+    if (!global.confirm('Delete this media item?')) return;
+    try {
+      const res = await global.fetch(`/api/vault-media/${id}`, {
+        method: 'DELETE',
+      });
+      const result = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        global.alert(result.error || 'Failed to delete media');
+        return;
+      }
+      await loadVaultMedia();
+    } catch (err) {
+      global.console.error('Error deleting vault media:', err);
     }
   }
 
@@ -340,6 +363,7 @@
     renderPpvTable,
     linkPreviewInclude,
     loadVaultMedia,
+    deleteVaultMedia,
     uploadMedia,
     savePpv,
     deletePpv,


### PR DESCRIPTION
## Summary
- add `DELETE /api/vault-media/:id` backend route that removes media from OnlyFans and cleans related DB rows
- expose media deletion controls in `loadVaultMedia` UI
- test vault media deletion workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f853ecd483218d9dd0804859249b