### PR TITLE
Run migrations via npm and enforce env validation

### DIFF
--- a/predeploy.html
+++ b/predeploy.html
@@ -52,6 +52,8 @@
 <p>If the browser shows the script code instead of running it, open the OFEM folder in Finder and double-click <code>addtodatabase.command</code> manually.</p>
 <p>This command is required each time new migrations are added to the project.</p>
 
+<p>You can also run <code>npm run migrate</code> to execute all migrations, including <code>migrate_add_vault_media.js</code> and <code>migrate_add_vault_lists.js</code>.</p>
+
 <h2>Run the App</h2>
 <p>Double‑click <code>start.command</code> to launch the server.</p>
 

--- a/scripts/predeploy.js
+++ b/scripts/predeploy.js
@@ -22,4 +22,4 @@ if (needsInstall()) {
   run('npm', ['install']);
 }
 
-run('node', ['migrate_all.js']);
+run('npm', ['run', 'migrate']);

--- a/setup-env.js
+++ b/setup-env.js
@@ -44,25 +44,45 @@ async function main() {
         'ONLYFANS_API_KEY is required to make OnlyFans API requests.',
       );
   }
-  const openaiKey = await prompt(
-    'Enter your OpenAI API Key (leave blank to skip): ',
-  );
+  let openaiKey = '';
+  while (!openaiKey) {
+    openaiKey = await prompt('Enter your OpenAI API Key (required): ');
+    if (!openaiKey)
+      console.log('OPENAI_API_KEY is required for OpenAI functionality.');
+  }
 
-  const dbName = await prompt(
-    'Enter your Database Name (leave blank to skip): ',
-  );
-  const dbUser = await prompt(
-    'Enter your Database User (leave blank to skip): ',
-  );
-  const dbPassword = await prompt(
-    'Enter your Database Password (leave blank to skip): ',
-  );
-  const dbHost = await prompt(
-    'Enter your Database Host (leave blank to skip): ',
-  );
-  const dbPort = await prompt(
-    'Enter your Database Port (leave blank to skip): ',
-  );
+  let dbName = '';
+  while (!dbName) {
+    dbName = await prompt('Enter your Database Name (required): ');
+    if (!dbName) console.log('Database name is required.');
+  }
+  let dbUser = '';
+  while (!dbUser) {
+    dbUser = await prompt('Enter your Database User (required): ');
+    if (!dbUser) console.log('Database user is required.');
+  }
+  let dbPassword = '';
+  while (!dbPassword) {
+    dbPassword = await prompt('Enter your Database Password (required): ');
+    if (!dbPassword) console.log('Database password is required.');
+  }
+  let dbHost = '';
+  while (!dbHost) {
+    dbHost = await prompt('Enter your Database Host (required): ');
+    if (!dbHost) console.log('Database host is required.');
+  }
+  let dbPort = '';
+  while (true) {
+    dbPort = await prompt('Enter your Database Port (required): ');
+    if (!dbPort) {
+      console.log('Database port is required.');
+    } else if (Number.isNaN(Number(dbPort))) {
+      console.log('Database port must be a number.');
+      dbPort = '';
+    } else {
+      break;
+    }
+  }
   const dbAdminUser = await prompt(
     'Enter your Database Admin User (optional, leave blank to skip): ',
   );
@@ -75,6 +95,22 @@ async function main() {
   const fetchLimit = await prompt(
     'Max OnlyFans records to fetch (leave blank for 1000): ',
   );
+
+  const requiredVars = {
+    ONLYFANS_API_KEY: onlyfansKey,
+    OPENAI_API_KEY: openaiKey,
+    DB_NAME: dbName,
+    DB_USER: dbUser,
+    DB_PASSWORD: dbPassword,
+    DB_HOST: dbHost,
+    DB_PORT: dbPort,
+  };
+  for (const [key, value] of Object.entries(requiredVars)) {
+    if (!value) {
+      console.error(`${key} is required. Aborting setup.`);
+      process.exit(1);
+    }
+  }
 
   const setEnv = (key, value) => {
     if (!value) return;


### PR DESCRIPTION
## Summary
- Ensure predeploy script executes `npm run migrate` so all migration files run
- Document optional `npm run migrate` step in predeploy guide
- Require OnlyFans API key, OpenAI API key, and database credentials in `setup-env.js` with early failures

## Testing
- `npm test` *(fails: expected call count mismatch in fans.test.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896faa47e3083218462ad9d201ba44c