### PR TITLE
Handle vault media fetch errors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -175,12 +175,25 @@
       async function loadVaultMedia() {
         try {
           const res = await fetch('/api/vault-media');
-          if (!res.ok) return;
+          const container = document.getElementById('vaultMediaList');
+          if (!res.ok) {
+            let err;
+            try {
+              err = await res.json();
+            } catch {}
+            const message =
+              (err && (err.error || err.message)) ||
+              'Failed to load vault media';
+            alert(message);
+            console.error('Error loading vault media:', message);
+            if (container) container.innerHTML = '';
+            return;
+          }
           const data = await res.json();
           const items = Array.isArray(data)
             ? data
             : data.list || data.results || data.media || data.data || [];
-          const container = document.getElementById('vaultMediaList');
+          if (!container) return;
           container.innerHTML = '';
           for (const m of items) {
             const div = document.createElement('div');

--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -79,10 +79,22 @@
     try {
       await fetchVaultLists();
       const res = await global.fetch('/api/vault-media');
-      if (!res.ok) return;
+      const container = global.document.getElementById('vaultMediaList');
+      if (!res.ok) {
+        let err;
+        try {
+          err = await res.json();
+        } catch {}
+        const message =
+          (err && (err.error || err.message)) ||
+          'Failed to load vault media';
+        if (global.alert) global.alert(message);
+        global.console.error('Error loading vault media:', message);
+        if (container) container.innerHTML = '';
+        return;
+      }
       const data = await res.json();
       const items = Array.isArray(data) ? data : [];
-      const container = global.document.getElementById('vaultMediaList');
       if (!container) return;
       container.innerHTML = '';
       for (const m of items) {


### PR DESCRIPTION
## Summary
- show error details when vault media fetch fails in PPV tool and clear stale items
- propagate same behavior on index page to keep error handling consistent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897070364c48321b3fef3961af68309