### PR TITLE
Support string media IDs for PPV messages

### DIFF
--- a/__tests__/ppv.test.js
+++ b/__tests__/ppv.test.js
@@ -220,8 +220,8 @@ test('sends PPV to fan and logs the send', async () => {
   expect(res.status).toBe(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
     text: '<p>hello</p>',
-    mediaFiles: [11],
-    previews: [11],
+    mediaFiles: ['11'],
+    previews: ['11'],
     price: 5,
     lockedText: false,
   });

--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -229,10 +229,34 @@ test('forwards media and price fields', async () => {
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
     text: '<p>Hello</p>',
-    mediaFiles: [1],
+    mediaFiles: ['1'],
     previews: [],
     price: 5,
     lockedText: true,
+  });
+});
+
+test('allows ofapi_media string IDs', async () => {
+  await mockPool.query(
+    "INSERT INTO fans (id, parker_name, username, location, isSubscribed, canReceiveChatMessage) VALUES (1,'Alice','user1','Wonderland',TRUE,TRUE)",
+  );
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValueOnce({});
+  await request(app)
+    .post('/api/sendMessage')
+    .send({
+      userId: 1,
+      greeting: '',
+      body: 'Hello',
+      mediaFiles: ['ofapi_media_123'],
+    })
+    .expect(200);
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
+    text: '<p>Hello</p>',
+    mediaFiles: ['ofapi_media_123'],
+    previews: [],
+    price: 0,
+    lockedText: false,
   });
 });
 

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const multer = require('multer');
 const FormData = require('form-data');
+const sanitizeMediaIds = require('../sanitizeMediaIds');
 
 module.exports = function ({
   getOFAccountId,
@@ -123,15 +124,9 @@ module.exports = function ({
       const greeting = req.body.greeting || '';
       const body = req.body.body || '';
 
-      // Normalize and sanitize media and preview arrays
-      let mediaFiles = Array.isArray(req.body.mediaFiles)
-        ? req.body.mediaFiles.map(Number).filter(Number.isFinite)
-        : [];
-      let previews = Array.isArray(req.body.previews)
-        ? req.body.previews.map(Number).filter(Number.isFinite)
-        : [];
-
-      // Deduplicate and remove overlaps
+      // Normalize IDs and remove duplicates/overlaps
+      let mediaFiles = sanitizeMediaIds(req.body.mediaFiles);
+      let previews = sanitizeMediaIds(req.body.previews);
       const mediaSet = new Set(mediaFiles);
       const previewSet = new Set(previews);
       for (const id of [...previewSet]) {
@@ -194,12 +189,8 @@ module.exports = function ({
       const scheduledTime = req.body.scheduledTime;
       const price = req.body.price;
       const lockedText = req.body.lockedText;
-      const mediaFiles = Array.isArray(req.body.mediaFiles)
-        ? req.body.mediaFiles
-        : [];
-      const previews = Array.isArray(req.body.previews)
-        ? req.body.previews
-        : [];
+      const mediaFiles = sanitizeMediaIds(req.body.mediaFiles);
+      const previews = sanitizeMediaIds(req.body.previews);
       if (recipients.length === 0 || (!greeting && !body) || !scheduledTime) {
         return res
           .status(400)

--- a/sanitizeMediaIds.js
+++ b/sanitizeMediaIds.js
@@ -1,0 +1,15 @@
+function sanitizeMediaIds(ids) {
+  if (!Array.isArray(ids)) return [];
+  return ids
+    .map((id) => {
+      if (typeof id === 'number' && Number.isFinite(id)) return String(id);
+      if (
+        typeof id === 'string' &&
+        (id.startsWith('ofapi_media_') || /^\d+$/.test(id))
+      )
+        return id;
+      return null;
+    })
+    .filter(Boolean);
+}
+module.exports = sanitizeMediaIds;

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ const path = require('path');
 const dotenv = require('dotenv');
 const getEditorHtml = require('./getEditorHtml');
 const { sanitizeError } = require('./sanitizeError');
+const sanitizeMediaIds = require('./sanitizeMediaIds');
 dotenv.config();
 
 // Database connection pool
@@ -302,12 +303,10 @@ let sendMessageToFan = async function (
     throw err;
   }
   const formatted = getEditorHtml(template);
-  const mediaIds = Array.isArray(mediaFiles)
-    ? mediaFiles.map(Number).filter(Number.isFinite)
-    : [];
-  const previewIds = Array.isArray(previews)
-    ? previews.map(Number).filter((id) => mediaIds.includes(id))
-    : [];
+  const mediaIds = sanitizeMediaIds(mediaFiles);
+  const previewIds = sanitizeMediaIds(previews).filter((id) =>
+    mediaIds.includes(id),
+  );
   const payload = {
     text: formatted,
     mediaFiles: mediaIds,


### PR DESCRIPTION
## Summary
- accept both numeric and `ofapi_media_*` IDs when sending messages
- sanitize media IDs and previews before dispatching
- test media handling including new string IDs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689708584b48832194e2e4011d9e5ed0