### PR TITLE
feat: add CDN scraping to PPV manager

### DIFF
--- a/__tests__/vaultMedia.test.js
+++ b/__tests__/vaultMedia.test.js
@@ -107,3 +107,18 @@ test('POST /api/vault-media uploads files', async () => {
   );
   expect(res.body).toEqual({ mediaIds: ['m1'] });
 });
+
+test('POST /api/vault-media/scrape uploads by URL', async () => {
+  mockAxios.get.mockResolvedValueOnce({ data: { accounts: [{ id: 'acc1' }] } });
+  mockAxios.post.mockResolvedValueOnce({ data: { id: 'm2' } });
+
+  const res = await request(app)
+    .post('/api/vault-media/scrape')
+    .send({ url: 'https://cdn1.onlyfans.com/file' })
+    .expect(200);
+
+  expect(mockAxios.post).toHaveBeenCalledWith('/acc1/media/scrape', {
+    url: 'https://cdn1.onlyfans.com/file',
+  });
+  expect(res.body).toEqual({ mediaId: 'm2' });
+});

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -140,6 +140,9 @@ input {
 .mt-5 {
   margin-top: 5px;
 }
+.mb-4 {
+  margin-bottom: 4px;
+}
 .mb-8 {
   margin-bottom: 8px;
 }

--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -188,6 +188,29 @@
     }
   }
 
+  async function scrapeMedia() {
+    const input = global.document.getElementById('cdnUrl');
+    if (!input) return;
+    const url = input.value.trim();
+    if (!url) return;
+    try {
+      const res = await global.fetch('/api/vault-media/scrape', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+      const result = await res.json();
+      if (!res.ok) {
+        global.alert(result.error || 'Failed to scrape media');
+        return;
+      }
+      input.value = '';
+      await loadVaultMedia();
+    } catch (err) {
+      global.console.error('Error scraping media:', err);
+    }
+  }
+
   async function savePpv() {
     const ppvNumber = parseInt(global.document.getElementById('ppvNumber').value, 10);
     const message = global.document.getElementById('message').value.trim();
@@ -332,6 +355,8 @@
     if (loadBtn) loadBtn.addEventListener('click', loadVaultMedia);
     const uploadBtn = global.document.getElementById('uploadMediaBtn');
     if (uploadBtn) uploadBtn.addEventListener('click', uploadMedia);
+    const scrapeBtn = global.document.getElementById('scrapeMediaBtn');
+    if (scrapeBtn) scrapeBtn.addEventListener('click', scrapeMedia);
     const saveBtn = global.document.getElementById('saveBtn');
     if (saveBtn) saveBtn.addEventListener('click', savePpv);
     const listSelect = global.document.getElementById('vaultListSelect');
@@ -353,6 +378,7 @@
     linkPreviewInclude,
     loadVaultMedia,
     uploadMedia,
+    scrapeMedia,
     savePpv,
     deletePpv,
     sendPpv,

--- a/public/ppv.html
+++ b/public/ppv.html
@@ -107,13 +107,28 @@
         >
       </fieldset>
       <div class="mb-8">
-        <button id="loadVaultBtn" type="button" class="btn btn-primary">
-          Load Vault Media
-        </button>
-        <input type="file" id="mediaUploadInput" multiple />
-        <button id="uploadMediaBtn" type="button" class="btn btn-secondary">
-          Upload Media
-        </button>
+        <div class="mb-4">
+          <label
+            >CDN URL:
+            <input
+              type="text"
+              id="cdnUrl"
+              class="form-input"
+              placeholder="https://cdn.onlyfans.com/..."
+          /></label>
+          <button id="scrapeMediaBtn" type="button" class="btn btn-secondary">
+            Scrape URL
+          </button>
+        </div>
+        <div class="mb-4">
+          <button id="loadVaultBtn" type="button" class="btn btn-primary">
+            Load Vault Media
+          </button>
+          <input type="file" id="mediaUploadInput" multiple />
+          <button id="uploadMediaBtn" type="button" class="btn btn-secondary">
+            Upload Media
+          </button>
+        </div>
         <div id="vaultMediaList" class="vault-media-list"></div>
       </div>
       <button id="saveBtn" type="button" class="btn btn-primary">


### PR DESCRIPTION
## Summary
- allow scraping OnlyFans CDN URLs into vault media
- expose scraping via new `/api/vault-media/scrape` endpoint
- enhance PPV manager UI with CDN URL input and scrape button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68970ad68e9083219637d4fbd1d9ef0d