### PR TITLE
Fix locked text handling for message sending

### DIFF
--- a/__tests__/ppv.test.js
+++ b/__tests__/ppv.test.js
@@ -223,7 +223,6 @@ test('sends PPV to fan and logs the send', async () => {
     mediaFiles: ['11'],
     previews: ['11'],
     price: 5,
-    lockedText: false,
   });
   const log = await mockPool.query(
     'SELECT ppv_id, fan_id FROM ppv_sends',

--- a/__tests__/scheduler.test.js
+++ b/__tests__/scheduler.test.js
@@ -145,7 +145,7 @@ test('sends PPV media from associated vault list', async () => {
     '',
     'hello',
     10,
-    false,
+    '',
     [111, 222],
     [],
   );
@@ -185,7 +185,7 @@ test('includes preview media when sending paywalled PPVs', async () => {
     '',
     'hi',
     7,
-    false,
+    '',
     [10, 20],
     [20],
   );

--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -75,7 +75,6 @@ test('replaces {parker_name} placeholder', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -98,7 +97,6 @@ test('replaces {username} placeholder', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -117,7 +115,6 @@ test('replaces {location} placeholder', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -136,7 +133,6 @@ test('inserts <br> for newline characters', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -159,7 +155,6 @@ test('keeps <strong> tag for bold formatting', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -182,7 +177,6 @@ test('retains font size class on span', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -205,7 +199,6 @@ test('retains font color class on span', async () => {
     mediaFiles: [],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -222,7 +215,7 @@ test('forwards media and price fields', async () => {
       greeting: '',
       body: 'Hello',
       price: 5,
-      lockedText: true,
+      lockedText: 'locked',
       mediaFiles: [1, 'x', 1, 2],
       previews: [2, 'y', 2],
     })
@@ -232,7 +225,7 @@ test('forwards media and price fields', async () => {
     mediaFiles: ['1'],
     previews: [],
     price: 5,
-    lockedText: true,
+    lockedText: 'locked',
   });
 });
 
@@ -256,7 +249,6 @@ test('allows ofapi_media string IDs', async () => {
     mediaFiles: ['ofapi_media_123'],
     previews: [],
     price: 0,
-    lockedText: false,
   });
 });
 
@@ -273,7 +265,7 @@ test('allows price when lockedText true without media', async () => {
       greeting: '',
       body: 'Hello',
       price: 5,
-      lockedText: true,
+      lockedText: 'secret',
     })
     .expect(200);
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/chats/1/messages', {
@@ -281,7 +273,7 @@ test('allows price when lockedText true without media', async () => {
     mediaFiles: [],
     previews: [],
     price: 5,
-    lockedText: true,
+    lockedText: 'secret',
   });
 });
 

--- a/public/queue.js
+++ b/public/queue.js
@@ -115,7 +115,9 @@
       } else {
         payload.price = null;
       }
-      payload.lockedText = locked;
+      payload.lockedText = locked
+        ? this.currentMessage.locked_text || ''
+        : null;
       try {
         const res = await global.fetch(
           `/api/scheduledMessages/${this.currentMessage.id}`,

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -169,8 +169,9 @@ module.exports = function ({
       mediaFiles = Array.from(mediaSet);
       previews = Array.from(previewSet);
 
-      // Determine whether text should be locked
-      const lockedText = req.body.lockedText === true;
+      // Locked text string (paywalled message)
+      const lockedText =
+        typeof req.body.lockedText === 'string' ? req.body.lockedText : '';
 
       // Parse price; default to 0 if NaN or neither media nor locked text
       let price = parseFloat(req.body.price);

--- a/routes/ppv.js
+++ b/routes/ppv.js
@@ -325,7 +325,7 @@ module.exports = function ({
         '',
         message,
         price,
-        false,
+        '',
         mediaFiles,
         previews,
       );

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -211,7 +211,7 @@ module.exports = function ({ pool, sanitizeError, sendMessageToFan, openaiAxios,
         const templateIndex = Math.floor(Math.random() * THANK_YOU_TEMPLATES.length);
         const thankYouTemplate = THANK_YOU_TEMPLATES[templateIndex];
         try {
-          await sendMessageToFan(fanId, '', thankYouTemplate, 0, false, [], []); // no media, no price, just text
+          await sendMessageToFan(fanId, '', thankYouTemplate, 0, '', [], []); // no media, no price, just text
           // sendMessageToFan already inserts the outgoing message into DB
         } catch (err) {
           if (err.code === 'FAN_NOT_ELIGIBLE') {

--- a/server.js
+++ b/server.js
@@ -268,11 +268,11 @@ let sendMessageToFan = async function (
   greeting = '',
   body = '',
   price = 0,
-  lockedText = false,
+  lockedText = '',
   mediaFiles = [],
   previews = [],
 ) {
-  if (!fanId || (!greeting && !body)) {
+  if (!fanId || (!greeting && !body && !lockedText && mediaFiles.length === 0)) {
     throw new Error('Missing userId or message.');
   }
   let template = [greeting, body].filter(Boolean).join(' ').trim();
@@ -295,7 +295,7 @@ let sendMessageToFan = async function (
   template = template.replace(/\{name\}|\[name\]|\{parker_name\}/g, parkerName);
   template = template.replace(/\{username\}/g, userName);
   template = template.replace(/\{location\}/g, userLocation);
-  if (template.trim().length === 0) {
+  if (template.trim().length === 0 && !lockedText) {
     const err = new Error(
       'Message template empty after placeholder substitution; provide fallback text.',
     );
@@ -312,8 +312,8 @@ let sendMessageToFan = async function (
     mediaFiles: mediaIds,
     previews: previewIds,
     price: typeof price === 'number' ? price : 0,
-    lockedText: lockedText === true,
   };
+  if (lockedText) payload.lockedText = lockedText;
   await ofApiRequest(() =>
     ofApi.post(`/${accountId}/chats/${fanId}/messages`, payload),
   );
@@ -558,7 +558,7 @@ async function processRecurringPPVs() {
             '',
             message || '',
             price,
-            false,
+            '',
             mediaFiles,
             previews,
           );


### PR DESCRIPTION
## Summary
- treat `lockedText` as a string when sending messages so paywalled text is passed to OnlyFans
- accept string `lockedText` in `POST /api/sendMessage` and forward it to message service
- update PPV, webhook, and queue flows to send an empty string when no locked text is used

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974fdc91b08321a1be148802e14c5b