### PR TITLE
Enable PPV editing with media selections

### DIFF
--- a/__tests__/ppv.test.js
+++ b/__tests__/ppv.test.js
@@ -161,6 +161,22 @@ test('saves and retrieves message field', async () => {
   expect(ppv.message).toBe('hello');
 });
 
+test('includes media arrays in GET /api/ppv', async () => {
+  const insertRes = await mockPool.query(
+    "INSERT INTO ppv_sets (ppv_number, message, price) VALUES (1,'msg',5) RETURNING id",
+  );
+  const id = insertRes.rows[0].id;
+  await mockPool.query(
+    'INSERT INTO ppv_media (ppv_id, media_id, is_preview) VALUES ($1,$2,$3)',
+    [id, 100, true],
+  );
+  const listRes = await request(app).get('/api/ppv');
+  expect(listRes.status).toBe(200);
+  const ppv = listRes.body.ppvs.find((p) => p.id === id);
+  expect(ppv.mediaFiles).toEqual([100]);
+  expect(ppv.previews).toEqual([100]);
+});
+
 test('resets last_sent_at when schedule changes', async () => {
   const insertRes = await mockPool.query(
     "INSERT INTO ppv_sets (ppv_number, description, message, price, schedule_day, schedule_time, last_sent_at) VALUES (1,'desc','msg',5,10,'10:00','2024-01-01T00:00:00Z') RETURNING id",

--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -430,7 +430,7 @@
     sendPpv(id, fanId);
   }
 
-  function editPpv(id) {
+  async function editPpv(id) {
     const ppv = currentPpvs.find((p) => p.id === id);
     if (!ppv) return;
     editingPpvId = id;
@@ -449,6 +449,25 @@
     if (dayInput) dayInput.value = ppv.scheduleDay != null ? ppv.scheduleDay : '';
     const timeInput = global.document.getElementById('scheduleTime');
     if (timeInput) timeInput.value = ppv.scheduleTime || '';
+    selectedVaultListId = ppv.vault_list_id || ppv.vaultListId || null;
+    await loadVaultMedia();
+    const mediaIds = ppv.mediaFiles || [];
+    const previewIds = ppv.previews || [];
+    for (const cb of global.document.querySelectorAll('.mediaCheckbox')) {
+      if (mediaIds.includes(Number(cb.value))) {
+        cb.checked = true;
+        cb.dispatchEvent(new global.Event('change'));
+      }
+    }
+    for (const cb of global.document.querySelectorAll('.previewCheckbox')) {
+      if (previewIds.includes(Number(cb.value))) {
+        cb.checked = true;
+        cb.dispatchEvent(new global.Event('change'));
+      }
+    }
+    const listSelect = global.document.getElementById('vaultListSelect');
+    if (listSelect)
+      listSelect.value = selectedVaultListId ? String(selectedVaultListId) : '';
     const saveBtn = global.document.getElementById('saveBtn');
     if (saveBtn) saveBtn.textContent = 'Update PPV';
   }


### PR DESCRIPTION
## Summary
- return associated media IDs when listing PPVs so the UI can pre-select them on edit
- allow editing of PPV templates in the browser, loading vault media, selecting the related vault list, and pre-checking selected media
- add regression test ensuring media arrays are included in GET /api/ppv

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b0cea51c832190ba660ca32235ba