### PR TITLE
feat: add vault list management UI

### DIFF
--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -387,6 +387,60 @@
     }
   }
 
+  async function renameVaultList() {
+    const select = global.document.getElementById('vaultListSelect');
+    const id = select && select.value;
+    if (!id) {
+      global.alert('Select a list first');
+      return;
+    }
+    const name = global.prompt('Enter new list name');
+    if (!name) return;
+    try {
+      const res = await global.fetch(`/api/vault-lists/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const result = await res.json();
+      if (!res.ok) {
+        global.alert(result.error || 'Failed to rename list');
+        return;
+      }
+      selectedVaultListId = Number(id);
+      await fetchVaultLists();
+      if (select) select.value = String(id);
+    } catch (err) {
+      global.console.error('Error renaming vault list:', err);
+    }
+  }
+
+  async function deleteVaultList() {
+    const select = global.document.getElementById('vaultListSelect');
+    const id = select && select.value;
+    if (!id) {
+      global.alert('Select a list first');
+      return;
+    }
+    if (!global.confirm('Delete this list?')) return;
+    try {
+      const res = await global.fetch(`/api/vault-lists/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const result = await res.json().catch(() => ({}));
+        global.alert(result.error || 'Failed to delete list');
+        return;
+      }
+      if (selectedVaultListId === Number(id)) {
+        selectedVaultListId = null;
+      }
+      await fetchVaultLists();
+    } catch (err) {
+      global.console.error('Error deleting vault list:', err);
+    }
+  }
+
   async function deletePpv(id) {
     if (!global.confirm('Delete this PPV?')) return;
     try {
@@ -489,6 +543,10 @@
     }
     const createListBtn = global.document.getElementById('createVaultListBtn');
     if (createListBtn) createListBtn.addEventListener('click', createVaultList);
+    const renameListBtn = global.document.getElementById('renameVaultListBtn');
+    if (renameListBtn) renameListBtn.addEventListener('click', renameVaultList);
+    const deleteListBtn = global.document.getElementById('deleteVaultListBtn');
+    if (deleteListBtn) deleteListBtn.addEventListener('click', deleteVaultList);
     fetchVaultLists();
     fetchPpvs();
   }
@@ -507,6 +565,8 @@
     sendPpvPrompt,
     editPpv,
     createVaultList,
+    renameVaultList,
+    deleteVaultList,
     fetchVaultLists,
     init,
   };

--- a/public/ppv.html
+++ b/public/ppv.html
@@ -69,6 +69,20 @@
         <button id="createVaultListBtn" type="button" class="btn btn-secondary">
           Create List
         </button>
+        <button
+          id="renameVaultListBtn"
+          type="button"
+          class="btn btn-secondary"
+        >
+          Rename List
+        </button>
+        <button
+          id="deleteVaultListBtn"
+          type="button"
+          class="btn btn-secondary"
+        >
+          Delete List
+        </button>
       </div>
       <fieldset class="schedule-section mb-8">
         <legend>Scheduling</legend>


### PR DESCRIPTION
## Summary
- add Rename List and Delete List controls to PPV page
- support renaming and deleting vault lists via new frontend helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897b2c778e08321888950ae4aa86fe5