### PR TITLE
feat: add vault media sync endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -356,6 +356,7 @@ const vaultListsRoutes = require('./routes/vaultLists')({
   ofApi,
   pool,
   sanitizeError,
+  OF_FETCH_LIMIT,
 });
 const messagesRoutes = require('./routes/messages')({
   getOFAccountId,


### PR DESCRIPTION
## Summary
- add `/vault-media` route to fetch OnlyFans vault media with pagination
- persist media metadata in `vault_media` table and return stored records
- pass `OF_FETCH_LIMIT` into vault routes and remove duplicate handler

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6897be93f8188321b19c8be7b8bba301