### PR TITLE
Render vault media results in table

### DIFF
--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -591,7 +591,32 @@ document.getElementById('loadVaultBtn').addEventListener('click', async () => {
       return;
     }
     const mediaItems = await res.json();
-    // TODO: display mediaItems in a table (see step 3)
+    const container = document.getElementById('vaultMediaList');
+    container.innerHTML = '';
+    if (mediaItems.length === 0) {
+      container.textContent = 'No media found in vault.';
+    } else {
+      let tableHtml =
+        '<table><thead><tr><th>ID</th><th>Media</th><th>Include</th><th>Preview</th><th>Likes</th><th>Tips</th></tr></thead><tbody>';
+      for (const m of mediaItems) {
+        const thumbUrl = m.preview_url || m.thumb_url || '';
+        tableHtml += '<tr>';
+        tableHtml += `<td>${m.id}</td>`;
+        tableHtml +=
+          '<td>' +
+          (thumbUrl
+            ? `<img src="${thumbUrl}" alt="media" style="max-width:80px;">`
+            : '') +
+          '</td>';
+        tableHtml += `<td><input type="checkbox" class="mediaCheckbox" value="${m.id}"></td>`;
+        tableHtml += `<td><input type="checkbox" class="previewCheckbox" value="${m.id}"></td>`;
+        tableHtml += `<td>${m.likes || 0}</td>`;
+        tableHtml += `<td>${m.tips || 0}</td>`;
+        tableHtml += '</tr>';
+      }
+      tableHtml += '</tbody></table>';
+      container.innerHTML = tableHtml;
+    }
   } catch (error) {
     console.error('Error fetching vault media:', error);
   }


### PR DESCRIPTION
## Summary
- Render vault media list as table with ID, thumbnail, include/preview checkboxes, likes, and tips columns.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897bfe46a5483218b96ee910d9426e3