### PR TITLE
feat: add mass messaging endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -609,7 +609,9 @@ async function initScheduling() {
     console.warn('ppv_sets table missing; skipping recurring PPV processing');
   }
   if (hasScheduledMessagesTable || hasPpvSetsTable) {
-    setInterval(processAllSchedules, 60000);
+    if (process.env.NODE_ENV !== 'test') {
+      setInterval(processAllSchedules, 60000);
+    }
     await processAllSchedules();
   }
 }


### PR DESCRIPTION
## Summary
- add `/send` endpoint to fan messages API for mass sends with concurrency control
- add `/schedule` endpoint to queue messages for later delivery
- skip scheduling intervals during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c6d76fd88321849e38041c541dab