### PR TITLE
Set explicit JSON body limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ app.use((req, res, next) => {
   res.setHeader('Server', 'OFEM');
   next();
 });
-app.use(express.json());
+app.use(express.json({ limit: '2mb' }));
 
 // OnlyFans API client (bearer auth)
 const ofApi = axios.create({


### PR DESCRIPTION
## Summary
- Increase Express JSON body size limit to 2MB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897c7023314832198e0b69385a94160