### PR TITLE
Expose vault media listing at root

### DIFF
--- a/routes/vaultLists.js
+++ b/routes/vaultLists.js
@@ -10,7 +10,7 @@ module.exports = function ({
 }) {
   const router = express.Router();
 
-  router.get('/vault-media', async (req, res) => {
+  async function listVaultMedia(req, res) {
     try {
       const accountId = await getOFAccountId();
       const limit = 100;
@@ -57,7 +57,10 @@ module.exports = function ({
         error: status === 400 ? err.message : 'Failed to fetch vault media',
       });
     }
-  });
+  }
+
+  router.get('/vault-media', listVaultMedia);
+  router.get('/', listVaultMedia);
 
   router.get('/vault-lists', async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- expose existing vault media listing handler on GET /
- keep /vault-media route for backward compatibility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c7090afc8321b2df129737e34497