### PR TITLE
feat: add UI handlers for media messaging

### DIFF
--- a/public/editor.js
+++ b/public/editor.js
@@ -96,3 +96,201 @@
     module.exports = Editor;
   }
 })(typeof window !== 'undefined' ? window : global);
+
+// Wire up Load Vault Media, Send, and Schedule actions. Render media table. Push status updates to the UI.
+
+if (typeof document !== 'undefined') {
+  (() => {
+    const $ = (sel) => document.querySelector(sel);
+
+    document.addEventListener('DOMContentLoaded', () => {
+      $('#btnLoadVaultMedia')?.addEventListener('click', loadVaultMedia);
+      $('#btnSendAll')?.addEventListener('click', () =>
+        sendMessages({ schedule: false }),
+      );
+      $('#btnSchedule')?.addEventListener('click', () =>
+        sendMessages({ schedule: true }),
+      );
+      $('#btnClearStatus')?.addEventListener('click', clearStatusUI);
+
+      // Delegate Save Parker Name per row
+      document.body.addEventListener('click', async (e) => {
+        const btn = e.target.closest('.saveParkerBtn');
+        if (!btn) return;
+        const userId = btn.dataset.userId;
+        const input = document.querySelector(
+          `input[data-parker-input="${userId}"]`,
+        );
+        const parkerName = input ? input.value.trim() : '';
+        if (!userId) return;
+        await saveParkerName(userId, parkerName);
+      });
+    });
+
+    async function loadVaultMedia() {
+      setBusy('#btnLoadVaultMedia', true);
+      try {
+        const res = await fetch('/api/vault-media');
+        const data = await res.json();
+        if (!res.ok)
+          throw new Error(data?.error || 'Failed to load vault media');
+        renderVaultMediaTable(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error(err);
+        alert(err.message || 'Failed to load vault media');
+      } finally {
+        setBusy('#btnLoadVaultMedia', false);
+      }
+    }
+
+    function renderVaultMediaTable(items) {
+      const container = $('#vaultMediaList');
+      if (!container) return;
+      if (!items.length) {
+        container.innerHTML = '<p>No media found.</p>';
+        return;
+      }
+      const rows = items
+        .map((m) => {
+          const id = sanitize(String(m.id ?? ''));
+          const thumb = sanitize(m.preview_url || m.thumb_url || '');
+          const likes = sanitize(String(m.likes ?? m.likesCount ?? 0));
+          const tips = sanitize(String(m.tips ?? 0));
+          return `
+        <tr>
+          <td><input type="checkbox" class="mediaCheckbox" value="${id}"></td>
+          <td>${id}</td>
+          <td>${thumb ? `<img src="${thumb}" alt="thumb" style="max-width:80px;max-height:80px;">` : ''}</td>
+          <td>${likes}</td>
+          <td>${tips}</td>
+        </tr>
+      `;
+        })
+        .join('');
+      container.innerHTML = `
+      <table class="table table-striped" id="vaultMediaTable">
+        <thead>
+          <tr><th>Pick</th><th>ID</th><th>Preview</th><th>Likes</th><th>Tips</th></tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+    }
+
+    function getSelectedMediaIds() {
+      return Array.from(
+        document.querySelectorAll('#vaultMediaTable .mediaCheckbox:checked'),
+      ).map((cb) => cb.value);
+    }
+
+    function buildPayload(scheduleFlag) {
+      const text = ($('#messageInput')?.value || '').trim();
+      const price = ($('#priceInput')?.value || '').trim();
+      const mediaIds = getSelectedMediaIds();
+      const date = $('#scheduleDateInput')?.value || '';
+      const time = $('#scheduleTimeInput')?.value || '';
+      let scheduleAt = null;
+      if (scheduleFlag && date && time) {
+        // Convert local date and time to ISO
+        const local = new Date(`${date}T${time}`);
+        scheduleAt = isNaN(local.getTime()) ? null : local.toISOString();
+      }
+      return {
+        text,
+        price: price ? Number(price) : null,
+        mediaIds,
+        scheduleAt,
+        scope: 'allActiveFans',
+      };
+    }
+
+    async function sendMessages({ schedule }) {
+      const payload = buildPayload(schedule);
+      if (!payload.text) {
+        alert('Message is required');
+        return;
+      }
+      const endpoint = schedule
+        ? '/api/messages/schedule'
+        : '/api/messages/send';
+      setBusy('#btnSendAll', true);
+      setBusy('#btnSchedule', true);
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        if (!res.ok)
+          throw new Error(data?.error || 'Failed to submit messages');
+        updateStatusUI(data);
+      } catch (err) {
+        console.error(err);
+        alert(err.message || 'Failed to send');
+      } finally {
+        setBusy('#btnSendAll', false);
+        setBusy('#btnSchedule', false);
+      }
+    }
+
+    async function saveParkerName(userId, parkerName) {
+      try {
+        const res = await fetch(
+          `/api/fans/${encodeURIComponent(userId)}/parker-name`,
+          {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ parkerName }),
+          },
+        );
+        const data = await res.json();
+        if (!res.ok)
+          throw new Error(data?.error || 'Failed to save Parker Name');
+        toast('Saved');
+      } catch (err) {
+        console.error(err);
+        alert(err.message || 'Failed to save');
+      }
+    }
+
+    function updateStatusUI(result) {
+      // Expecting result to include totals and maybe per user statuses
+      // Example: { queued, sent, failed, errors: [{userId, message}] }
+      if (result?.errors?.length) {
+        console.table(result.errors);
+      }
+      toast('Submitted');
+    }
+
+    function clearStatusUI() {
+      // Clear any status indicators in the table
+      document
+        .querySelectorAll('.statusDot')
+        .forEach((el) => el.classList.remove('ok', 'fail'));
+    }
+
+    function setBusy(sel, busy) {
+      const el = typeof sel === 'string' ? document.querySelector(sel) : sel;
+      if (!el) return;
+      el.disabled = !!busy;
+    }
+
+    function sanitize(s) {
+      return s.replace(
+        /[<>&"]/g,
+        (c) =>
+          ({
+            '<': '&lt;',
+            '>': '&gt;',
+            '&': '&amp;',
+            '"': '&quot;',
+          })[c],
+      );
+    }
+
+    function toast(msg) {
+      console.log(msg);
+    }
+  })();
+}


### PR DESCRIPTION
## Summary
- hook up front-end actions for loading vault media, sending or scheduling messages, and clearing status
- render vault media table and update status UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c7601f408321aefeed36a887346d