### PR TITLE
Add SQL migration for vault_media table

### DIFF
--- a/migrate_add_vault_media.sql
+++ b/migrate_add_vault_media.sql
@@ -1,0 +1,10 @@
+-- Ensure a vault_media table exists for caching. Run via your migration tool.
+
+CREATE TABLE IF NOT EXISTS vault_media (
+  id BIGINT PRIMARY KEY,
+  thumb_url TEXT,
+  preview_url TEXT,
+  likes INT,
+  tips INT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add SQL migration to create the `vault_media` table for caching media metadata

## Testing
- `npm test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6897c722ed8483219dfc0fafd94b0a02