### PR TITLE
Use editor-style loader for PPV media

### DIFF
--- a/public/js/ppv.js
+++ b/public/js/ppv.js
@@ -78,7 +78,15 @@
     updateLabel();
   }
 
+  function setBusy(sel, busy) {
+    const el =
+      typeof sel === 'string' ? global.document.querySelector(sel) : sel;
+    if (!el) return;
+    el.disabled = !!busy;
+  }
+
   async function loadVaultMedia() {
+    setBusy('#btnLoadVaultMedia', true);
     try {
       await fetchVaultLists();
       const res = await global.fetch('/api/vault-media');
@@ -164,6 +172,8 @@
       }
     } catch (err) {
       global.console.error('Error loading vault media:', err);
+    } finally {
+      setBusy('#btnLoadVaultMedia', false);
     }
   }
 
@@ -581,45 +591,3 @@
   global.document.addEventListener('DOMContentLoaded', init);
 })(typeof window !== 'undefined' ? window : global);
 
-// Fetch the vault media list when the "Load Vault Media" button is clicked
-document
-  .getElementById('btnLoadVaultMedia')
-  .addEventListener('click', async () => {
-    try {
-      const res = await fetch('/api/vault-media');
-      if (!res.ok) {
-        const err = await res.json();
-        alert(err.error || err.message || 'Failed to load vault media');
-        return;
-      }
-      const mediaItems = await res.json();
-      const container = document.getElementById('vaultMediaList');
-      container.innerHTML = '';
-      if (mediaItems.length === 0) {
-        container.textContent = 'No media found in vault.';
-      } else {
-        let tableHtml =
-          '<table><thead><tr><th>ID</th><th>Media</th><th>Include</th><th>Preview</th><th>Likes</th><th>Tips</th></tr></thead><tbody>';
-        for (const m of mediaItems) {
-          const thumbUrl = m.preview_url || m.thumb_url || '';
-          tableHtml += '<tr>';
-          tableHtml += `<td>${m.id}</td>`;
-          tableHtml +=
-            '<td>' +
-            (thumbUrl
-              ? `<img src="${thumbUrl}" alt="media" style="max-width:80px;">`
-              : '') +
-            '</td>';
-          tableHtml += `<td><input type="checkbox" class="mediaCheckbox" value="${m.id}"></td>`;
-          tableHtml += `<td><input type="checkbox" class="previewCheckbox" value="${m.id}"></td>`;
-          tableHtml += `<td>${m.likes || 0}</td>`;
-          tableHtml += `<td>${m.tips || 0}</td>`;
-          tableHtml += '</tr>';
-        }
-        tableHtml += '</tbody></table>';
-        container.innerHTML = tableHtml;
-      }
-    } catch (error) {
-      console.error('Error fetching vault media:', error);
-    }
-  });


### PR DESCRIPTION
## Summary
- Disable the "Load Vault Media" button while fetching, mirroring editor.js loader
- Remove duplicate vault media click handler in ppv.js

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897cc940b388321a87f7cce1d245cc4