### PR TITLE
fix: capture editor message html

### DIFF
--- a/public/editor.js
+++ b/public/editor.js
@@ -184,7 +184,7 @@ if (typeof document !== 'undefined') {
     }
 
     function buildPayload(scheduleFlag) {
-      const text = ($('#messageInput')?.value || '').trim();
+      const text = ($('#messageInput')?.innerHTML || '').trim();
       const price = ($('#priceInput')?.value || '').trim();
       const mediaIds = getSelectedMediaIds();
       const date = $('#scheduleDateInput')?.value || '';


### PR DESCRIPTION
## Summary
- capture HTML content from `#messageInput` when building message payload

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f23008dc8321aaade5ec156adc87