### PR TITLE
Include locked text in mass messaging

### DIFF
--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -1,10 +1,58 @@
+const { newDb } = require('pg-mem');
+const express = require('express');
 const request = require('supertest');
-const app = require('../server');
+
+const mem = newDb();
+const pg = mem.adapters.createPg();
+const pool = new pg.Pool();
+
+beforeAll(async () => {
+  await pool.query(`
+    CREATE TABLE fans (
+      id BIGINT PRIMARY KEY,
+      isSubscribed BOOLEAN,
+      canReceiveChatMessage BOOLEAN
+    );
+  `);
+});
+
+beforeEach(async () => {
+  await pool.query('DELETE FROM fans');
+});
+
+function createApp(sendMessageToFan) {
+  const app = express();
+  app.use(express.json());
+  const router = require('../routes/messages')({
+    getOFAccountId: jest.fn(),
+    ofApiRequest: jest.fn(),
+    ofApi: {},
+    pool,
+    sanitizeError: (e) => e,
+    sendMessageToFan,
+    getMissingEnvVars: () => [],
+  });
+  app.use('/api', router);
+  return app;
+}
 
 describe('POST /api/messages/send', () => {
   it('rejects when text missing', async () => {
+    const app = createApp(jest.fn());
     const res = await request(app).post('/api/messages/send').send({});
     expect(res.status).toBe(400);
   });
-});
 
+  it('passes lockedText to sendMessageToFan', async () => {
+    await pool.query(
+      `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`
+    );
+    const sendSpy = jest.fn().mockResolvedValue();
+    const app = createApp(sendSpy);
+    await request(app)
+      .post('/api/messages/send')
+      .send({ text: 'hi', price: 5, lockedText: 'secret' })
+      .expect(200);
+    expect(sendSpy).toHaveBeenCalledWith(1, '', 'hi', 5, 'secret', [], []);
+  });
+});

--- a/public/editor.js
+++ b/public/editor.js
@@ -187,6 +187,7 @@ if (typeof document !== 'undefined') {
       const messageEl = document.querySelector('#messageInput');
       const text = (messageEl?.innerHTML || '').trim();
       const price = ($('#priceInput')?.value || '').trim();
+      const lockedText = ($('#lockedText')?.value || '').trim();
       const mediaIds = getSelectedMediaIds();
       const date = $('#scheduleDateInput')?.value || '';
       const time = $('#scheduleTimeInput')?.value || '';
@@ -196,13 +197,15 @@ if (typeof document !== 'undefined') {
         const local = new Date(`${date}T${time}`);
         scheduleAt = isNaN(local.getTime()) ? null : local.toISOString();
       }
-      return {
+      const payload = {
         text,
         price: price ? Number(price) : null,
         mediaIds,
         scheduleAt,
         scope: 'allActiveFans',
       };
+      if (lockedText) payload.lockedText = lockedText;
+      return payload;
     }
 
     async function sendMessages({ schedule }) {

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -88,13 +88,6 @@ module.exports = function ({
     }
   });
 
-  router.post('/messages/send', async (req, res) => {
-    const text = req.body?.text;
-    if (typeof text !== 'string' || !text.trim()) {
-      return res.status(400).json({ error: 'text required' });
-    }
-    res.json({ success: true });
-  });
   /* Story 2: Send Personalized DM to All Fans */
   router.post('/sendMessage', async (req, res) => {
     const missing = getMissingEnvVars();
@@ -274,7 +267,7 @@ module.exports = function ({
     }
   });
 
-  router.post('/send', async (req, res) => {
+  router.post('/messages/send', async (req, res) => {
     const missing = getMissingEnvVars();
     if (missing.length) {
       return res.status(400).json({
@@ -282,7 +275,8 @@ module.exports = function ({
       });
     }
     try {
-      const { text, price, mediaIds, scope, recipients } = req.body || {};
+      const { text, price, lockedText, mediaIds, scope, recipients } =
+        req.body || {};
       if (!text || typeof text !== 'string') {
         return res.status(400).json({ error: 'text is required' });
       }
@@ -310,7 +304,7 @@ module.exports = function ({
               '',
               text,
               typeof price === 'number' ? price : parseFloat(price) || 0,
-              '',
+              typeof lockedText === 'string' ? lockedText : '',
               Array.isArray(mediaIds) ? mediaIds : [],
               [],
             );


### PR DESCRIPTION
## Summary
- send locked text with mass messages
- add front-end payload field and API support
- add test for locked text propagation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980e2d8678832193a666ff53203f0c