### PR TITLE
Expose recipient resolution endpoint for debugging

### DIFF
--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -446,3 +446,12 @@ test('updateParkerNames status endpoint reflects progress', async () => {
     .expect(200);
   expect(statusAfter.body.inProgress).toBe(false);
 });
+
+test('GET /api/recipients/resolve returns active fan IDs', async () => {
+  await pool.query(
+    `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE), (2, FALSE, TRUE), (3, TRUE, FALSE)`,
+  );
+  const res = await request(app).get('/api/recipients/resolve').expect(200);
+  expect(res.body.count).toBe(1);
+  expect(res.body.recipients).toEqual(['1']);
+});

--- a/routes/fans.js
+++ b/routes/fans.js
@@ -16,6 +16,54 @@ module.exports = function ({
 }) {
   const router = express.Router();
 
+  async function getActiveFans({ allowAllIfEmpty = true } = {}) {
+    const { rows } = await pool.query('SELECT * FROM fans');
+    const allIds = [];
+    const activeIds = [];
+    let hasActiveCol = false;
+    for (const r of rows) {
+      const id =
+        r.of_user_id ??
+        r.ofuserid ??
+        r.user_id ??
+        r.userid ??
+        r.id;
+      if (id == null || id === 'null' || id === 0) continue;
+      const idText = String(id);
+      allIds.push(idText);
+      const activeFlag =
+        r.active ??
+        r.is_active ??
+        r.subscribed ??
+        r.is_subscribed ??
+        (r.issubscribed !== undefined || r.canreceivechatmessage !== undefined
+          ? r.issubscribed && r.canreceivechatmessage
+          : undefined);
+      if (activeFlag !== undefined && activeFlag !== null) {
+        hasActiveCol = true;
+        if (activeFlag) activeIds.push(idText);
+      }
+    }
+    let list = hasActiveCol ? activeIds : allIds;
+    if ((!list || list.length === 0) && allowAllIfEmpty) {
+      list = allIds;
+    }
+    return list;
+  }
+
+  router.get('/recipients/resolve', async (req, res) => {
+    try {
+      const list = await getActiveFans({ allowAllIfEmpty: true });
+      res.json({ count: list.length, recipients: list.slice(0, 200) });
+    } catch (err) {
+      console.error(
+        'Error in GET /api/recipients/resolve:',
+        sanitizeError(err),
+      );
+      res.status(500).json({ error: 'failed to resolve recipients' });
+    }
+  });
+
   router.post('/refreshFans', async (req, res) => {
     const missing = [];
     if (!process.env.ONLYFANS_API_KEY) missing.push('ONLYFANS_API_KEY');


### PR DESCRIPTION
## Summary
- add `GET /api/recipients/resolve` endpoint to debug active recipient IDs
- include helper to resolve active fans and limit response to first 200
- cover recipient resolution with new Jest test

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68982bfccb6c8321961b05945b4cdf22