### PR TITLE
fix mass DM recipient resolution

### DIFF
--- a/routes/fans.js
+++ b/routes/fans.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const getActiveFans = require('../utils/getActiveFans');
 
 module.exports = function ({
   getOFAccountId,
@@ -16,44 +17,9 @@ module.exports = function ({
 }) {
   const router = express.Router();
 
-  async function getActiveFans({ allowAllIfEmpty = true } = {}) {
-    const { rows } = await pool.query('SELECT * FROM fans');
-    const allIds = [];
-    const activeIds = [];
-    let hasActiveCol = false;
-    for (const r of rows) {
-      const id =
-        r.of_user_id ??
-        r.ofuserid ??
-        r.user_id ??
-        r.userid ??
-        r.id;
-      if (id == null || id === 'null' || id === 0) continue;
-      const idText = String(id);
-      allIds.push(idText);
-      const activeFlag =
-        r.active ??
-        r.is_active ??
-        r.subscribed ??
-        r.is_subscribed ??
-        (r.issubscribed !== undefined || r.canreceivechatmessage !== undefined
-          ? r.issubscribed && r.canreceivechatmessage
-          : undefined);
-      if (activeFlag !== undefined && activeFlag !== null) {
-        hasActiveCol = true;
-        if (activeFlag) activeIds.push(idText);
-      }
-    }
-    let list = hasActiveCol ? activeIds : allIds;
-    if ((!list || list.length === 0) && allowAllIfEmpty) {
-      list = allIds;
-    }
-    return list;
-  }
-
   router.get('/recipients/resolve', async (req, res) => {
     try {
-      const list = await getActiveFans({ allowAllIfEmpty: true });
+      const list = await getActiveFans(pool, { allowAllIfEmpty: true });
       res.json({ count: list.length, recipients: list.slice(0, 200) });
     } catch (err) {
       console.error(

--- a/utils/getActiveFans.js
+++ b/utils/getActiveFans.js
@@ -1,0 +1,38 @@
+module.exports = async function getActiveFans(pool, { allowAllIfEmpty = true } = {}) {
+  const { rows } = await pool.query('SELECT * FROM fans');
+  const allIds = [];
+  const activeIds = [];
+  let hasActiveCol = false;
+  for (const r of rows) {
+    const id =
+      r.of_user_id ??
+      r.ofuserid ??
+      r.user_id ??
+      r.userid ??
+      r.id;
+    if (id == null || id === 'null' || id === 0) continue;
+    const idText = String(id);
+    allIds.push(idText);
+    const activeFlag =
+      r.active ??
+      r.is_active ??
+      r.subscribed ??
+      r.is_subscribed ??
+      (r.issubscribed !== undefined ||
+      r.canreceivechatmessage !== undefined ||
+      r.isSubscribed !== undefined ||
+      r.canReceiveChatMessage !== undefined
+        ? (r.issubscribed ?? r.isSubscribed) &&
+          (r.canreceivechatmessage ?? r.canReceiveChatMessage)
+        : undefined);
+    if (activeFlag !== undefined && activeFlag !== null) {
+      hasActiveCol = true;
+      if (activeFlag) activeIds.push(idText);
+    }
+  }
+  let list = hasActiveCol ? activeIds : allIds;
+  if ((!list || list.length === 0) && allowAllIfEmpty) {
+    list = allIds;
+  }
+  return list;
+};


### PR DESCRIPTION
## Summary
- extract shared `getActiveFans` utility checking `isSubscribed` and `canReceiveChatMessage`
- refactor fan and message routes to use new helper
- update send-message tests for production schema and add eligibility cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689909fe95a08321a3f1c6c1e5034689