### PR TITLE
Normalize fans subscription column

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ their purposes are:
 - `isRestricted` – Fan is restricted from certain interactions
 - `isHidden` – Profile is hidden from the creator
 - `isBookmarked` – Fan is bookmarked
-- `isSubscribed` – Active subscription status
+- `issubscribed` – Active subscription status
 - `subscribedBy` – Who initiated the subscription
 - `subscribedOn` – When the subscription started
 - `subscribedUntil` – Subscription expiration date
@@ -220,7 +220,7 @@ apply all migrations to an existing database in one step.
 
 Open <http://localhost:3000/follow.html> to follow back users who are not yet
 subscribed. The page calls `GET /api/fans/unfollowed` to list accounts where
-`isSubscribed` is `false`. Selecting **Follow All** issues a `POST
+`issubscribed` is `false`. Selecting **Follow All** issues a `POST
 /api/fans/:id/follow` for each entry.
 
 Requests are throttled with a 500 ms delay to respect OnlyFans rate limits. The
@@ -264,7 +264,7 @@ database. Each fan includes:
 - `id`, `username`, `name`, `parker_name`, `is_custom`
 - Profile details: `avatar`, `header`, `website`, `location`, `gender`, `birthday`, `about`, `notes`
 - Activity data: `lastSeen`, `joined`, `canReceiveChatMessage`, `canSendChatMessage`
-- Status flags: `isBlocked`, `isMuted`, `isRestricted`, `isHidden`, `isBookmarked`, `isSubscribed`, `isFriend`, `renewedAd`
+- Status flags: `isBlocked`, `isMuted`, `isRestricted`, `isHidden`, `isBookmarked`, `issubscribed`, `isFriend`, `renewedAd`
 - Subscription info: `subscribedBy`, `subscribedOn`, `subscribedUntil`, `subscribedByData`, `subscribedOnData`, `promoOffers`
 - Counts: `tipsSum`, `postsCount`, `photosCount`, `videosCount`, `audiosCount`, `mediaCount`, `subscribersCount`, `favoritesCount`
 - Media fields: `avatarThumbs`, `headerSize`, `headerThumbs`, `listsStates`
@@ -283,7 +283,7 @@ database. Each fan includes:
       "is_custom": false,
       "avatar": "https://cdn.example.com/avatar.jpg",
       "location": "USA",
-      "isSubscribed": true,
+      "issubscribed": true,
       "tipsSum": 100,
       "avatarThumbs": { "150": "https://cdn.example.com/avatar_150.jpg" },
       "promoOffers": {},

--- a/__tests__/fans.test.js
+++ b/__tests__/fans.test.js
@@ -35,7 +35,7 @@ CREATE TABLE fans (
     isRestricted BOOLEAN,
     isHidden BOOLEAN,
     isBookmarked BOOLEAN,
-    isSubscribed BOOLEAN,
+    issubscribed BOOLEAN,
     subscribedBy TEXT,
     subscribedOn TEXT,
     subscribedUntil TEXT,
@@ -115,7 +115,7 @@ test('inserts and retrieves fan with new columns', async () => {
     avatar: 'avatar1',
     website: 'https://example.com',
     lastSeen: ts,
-    isSubscribed: false,
+    issubscribed: false,
     tipsSum: 100,
     avatarThumbs: { foo: 1 },
   };
@@ -145,7 +145,7 @@ test('inserts and retrieves fan with new columns', async () => {
     username: 'user1',
     avatar: 'avatar1',
     website: 'https://example.com',
-    isSubscribed: false,
+    issubscribed: false,
     tipsSum: 100,
     avatarThumbs: { foo: 1 },
     parker_name: 'Alice',
@@ -171,7 +171,7 @@ test('updates existing fan fields', async () => {
     ...fanData1,
     avatar: 'avatar2',
     website: 'https://new.example.com',
-    isSubscribed: true,
+    issubscribed: true,
     tipsSum: 200,
     avatarThumbs: { foo: 2 },
   };
@@ -212,7 +212,7 @@ test('updates existing fan fields', async () => {
   expect(fan).toMatchObject({
     avatar: 'avatar2',
     website: 'https://new.example.com',
-    isSubscribed: true,
+    issubscribed: true,
     tipsSum: 200,
     avatarThumbs: { foo: 2 },
     parker_name: 'Alice',
@@ -297,7 +297,7 @@ test('merges fans and followings without duplication', async () => {
   const followingDb = res.body.fans.find((f) => f.id === 2);
   expect(fanDb).toMatchObject({
     avatar: 'a2',
-    isSubscribed: true,
+    issubscribed: true,
     parker_name: 'Alice',
   });
   expect(followingDb).toMatchObject({ username: 'user2', parker_name: 'Bob' });
@@ -394,7 +394,7 @@ test('PUT /api/fans/:id/parker-name updates Parker Name', async () => {
 
 test('POST /api/fans/followAll streams progress and updates DB', async () => {
   await pool.query(
-    `INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false), (2, 'user2', false)`,
+    `INSERT INTO fans (id, username, issubscribed) VALUES (1, 'user1', false), (2, 'user2', false)`,
   );
 
   mockAxios.get.mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } });
@@ -407,7 +407,7 @@ test('POST /api/fans/followAll streams progress and updates DB', async () => {
   expect(res.text).toContain('"done":true');
 
   const dbRes = await pool.query(
-    'SELECT id, isSubscribed FROM fans ORDER BY id',
+    'SELECT id, issubscribed FROM fans ORDER BY id',
   );
   expect(dbRes.rows).toEqual([
     { id: 1, issubscribed: true },
@@ -449,7 +449,7 @@ test('updateParkerNames status endpoint reflects progress', async () => {
 
 test('GET /api/recipients/resolve returns active fan IDs', async () => {
   await pool.query(
-    `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE), (2, FALSE, TRUE), (3, TRUE, FALSE)`,
+    `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE), (2, FALSE, TRUE), (3, TRUE, FALSE)`,
   );
   const res = await request(app).get('/api/recipients/resolve').expect(200);
   expect(res.body.count).toBe(1);

--- a/__tests__/followFans.test.js
+++ b/__tests__/followFans.test.js
@@ -22,7 +22,7 @@ beforeAll(async () => {
     CREATE TABLE fans (
       id BIGINT PRIMARY KEY,
       username TEXT,
-      isSubscribed BOOLEAN
+      issubscribed BOOLEAN
     );
   `);
   app = require('../server');
@@ -36,7 +36,7 @@ beforeEach(async () => {
 
 test('GET /api/fans/unfollowed returns only unsubscribed fans', async () => {
   await pool.query(
-    "INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false), (2, 'user2', true)",
+    "INSERT INTO fans (id, username, issubscribed) VALUES (1, 'user1', false), (2, 'user2', true)",
   );
 
   const res = await request(app).get('/api/fans/unfollowed').expect(200);
@@ -45,7 +45,7 @@ test('GET /api/fans/unfollowed returns only unsubscribed fans', async () => {
 
 test('POST /api/fans/:id/follow calls OnlyFans API and updates DB', async () => {
   await pool.query(
-    "INSERT INTO fans (id, username, isSubscribed) VALUES (1, 'user1', false)",
+    "INSERT INTO fans (id, username, issubscribed) VALUES (1, 'user1', false)",
   );
 
   mockAxios.get.mockResolvedValueOnce({ data: { data: [{ id: 'acc1' }] } });
@@ -54,7 +54,7 @@ test('POST /api/fans/:id/follow calls OnlyFans API and updates DB', async () => 
   await request(app).post('/api/fans/1/follow').expect(200);
 
   expect(mockAxios.post).toHaveBeenCalledWith('/acc1/users/1/follow');
-  const dbRes = await pool.query('SELECT isSubscribed FROM fans WHERE id=1');
+  const dbRes = await pool.query('SELECT issubscribed FROM fans WHERE id=1');
   expect(dbRes.rows[0].issubscribed).toBe(true);
 });
 

--- a/__tests__/ppv.test.js
+++ b/__tests__/ppv.test.js
@@ -46,7 +46,7 @@ beforeAll(async () => {
       parker_name TEXT,
       username TEXT,
       location TEXT,
-      isSubscribed BOOLEAN,
+      issubscribed BOOLEAN,
       canReceiveChatMessage BOOLEAN
     );
   `);
@@ -218,7 +218,7 @@ test('does not reset last_sent_at when schedule unchanged', async () => {
 
 test('sends PPV to fan and logs the send', async () => {
   await mockPool.query(
-    "INSERT INTO fans (id, parker_name, username, location, isSubscribed, canReceiveChatMessage) VALUES (1,'Alice','user1','Wonderland',TRUE,TRUE)",
+    "INSERT INTO fans (id, parker_name, username, location, issubscribed, canReceiveChatMessage) VALUES (1,'Alice','user1','Wonderland',TRUE,TRUE)",
   );
   const ppvRes = await mockPool.query(
     "INSERT INTO ppv_sets (ppv_number, message, price) VALUES (1,'hello',5) RETURNING id",

--- a/__tests__/scheduler.test.js
+++ b/__tests__/scheduler.test.js
@@ -22,7 +22,7 @@ beforeAll(async () => {
     CREATE TABLE fans (
       id BIGSERIAL PRIMARY KEY,
       username TEXT,
-      isSubscribed BOOLEAN,
+      issubscribed BOOLEAN,
       canReceiveChatMessage BOOLEAN
     );
   `);
@@ -76,7 +76,7 @@ afterEach(() => {
 
 test('recurring PPVs send once per fan per month across cycles', async () => {
   await mockPool.query(
-    `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE), (2, TRUE, TRUE);`,
+    `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE), (2, TRUE, TRUE);`,
   );
   await mockPool.query(
     `INSERT INTO ppv_sets (id, description, message, price, schedule_day, schedule_time) VALUES (1, 'desc', 'msg', 5, 15, '10:05');`,
@@ -118,7 +118,7 @@ test('recurring PPVs send once per fan per month across cycles', async () => {
 
 test('sends PPV media from associated vault list', async () => {
   await mockPool.query(
-    `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`,
+    `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`,
   );
   await mockPool.query(
     `INSERT INTO ppv_sets (id, message, price, vault_list_id, schedule_day, schedule_time) VALUES (1, 'hello', 10, 123, 15, '10:05');`,
@@ -158,7 +158,7 @@ test('sends PPV media from associated vault list', async () => {
 
 test('includes preview media when sending paywalled PPVs', async () => {
   await mockPool.query(
-    `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`,
+    `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`,
   );
   await mockPool.query(
     `INSERT INTO ppv_sets (id, message, price, schedule_day, schedule_time) VALUES (1, 'hi', 7, 15, '10:05');`,

--- a/__tests__/sendMessage.test.js
+++ b/__tests__/sendMessage.test.js
@@ -29,7 +29,7 @@ beforeAll(async () => {
       isRestricted BOOLEAN,
       isHidden BOOLEAN,
       isBookmarked BOOLEAN,
-      isSubscribed BOOLEAN
+      issubscribed BOOLEAN
     );
   `);
 });
@@ -65,7 +65,7 @@ describe('POST /api/messages/send', () => {
     const sendSpy = jest.fn().mockResolvedValue();
     const app = createApp(sendSpy);
     await pool.query(
-      `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (123, TRUE, TRUE);`,
+      `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (123, TRUE, TRUE);`,
     );
     const res = await request(app)
       .post('/api/messages/send')
@@ -77,7 +77,7 @@ describe('POST /api/messages/send', () => {
 
   it('passes lockedText to sendMessageToFan', async () => {
     await pool.query(
-      `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`
+      `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (1, TRUE, TRUE);`
     );
     const sendSpy = jest.fn().mockResolvedValue();
     const app = createApp(sendSpy);
@@ -91,7 +91,7 @@ describe('POST /api/messages/send', () => {
   it('returns no recipients resolved when fan cannot receive messages', async () => {
     const app = createApp(jest.fn());
     await pool.query(
-      `INSERT INTO fans (id, isSubscribed, canReceiveChatMessage) VALUES (5, TRUE, FALSE);`,
+      `INSERT INTO fans (id, issubscribed, canReceiveChatMessage) VALUES (5, TRUE, FALSE);`,
     );
     const res = await request(app)
       .post('/api/messages/send')

--- a/migrate.js
+++ b/migrate.js
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS fans (
     isRestricted BOOLEAN,
     isHidden BOOLEAN,
     isBookmarked BOOLEAN,
-    isSubscribed BOOLEAN,
+    issubscribed BOOLEAN,
     subscribedBy TEXT,
     subscribedOn TEXT,
     subscribedUntil TEXT,
@@ -81,7 +81,7 @@ ALTER TABLE fans
     ADD COLUMN IF NOT EXISTS isRestricted BOOLEAN,
     ADD COLUMN IF NOT EXISTS isHidden BOOLEAN,
     ADD COLUMN IF NOT EXISTS isBookmarked BOOLEAN,
-    ADD COLUMN IF NOT EXISTS isSubscribed BOOLEAN,
+    ADD COLUMN IF NOT EXISTS issubscribed BOOLEAN,
     ADD COLUMN IF NOT EXISTS subscribedBy TEXT,
     ADD COLUMN IF NOT EXISTS subscribedOn TEXT,
     ADD COLUMN IF NOT EXISTS subscribedUntil TEXT,
@@ -119,6 +119,16 @@ ALTER TABLE fans
 
 (async () => {
   try {
+    const { rows: colRows } = await pool.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'fans';`
+    );
+    const hasCamel = colRows.some((r) => r.column_name === 'isSubscribed');
+    const hasLower = colRows.some((r) => r.column_name === 'issubscribed');
+    if (hasCamel && !hasLower) {
+      await pool.query(
+        'ALTER TABLE fans RENAME COLUMN "isSubscribed" TO issubscribed;'
+      );
+    }
     await pool.query(createTableQuery);
     await pool.query(addColumnsQuery);
     console.log('✅ "fans" table has been created/updated.');

--- a/migrate_add_fan_fields.js
+++ b/migrate_add_fan_fields.js
@@ -30,7 +30,7 @@ const columns = [
   ['isRestricted', 'BOOLEAN'],
   ['isHidden', 'BOOLEAN'],
   ['isBookmarked', 'BOOLEAN'],
-  ['isSubscribed', 'BOOLEAN'],
+  ['issubscribed', 'BOOLEAN'],
   ['subscribedBy', 'TEXT'],
   ['subscribedOn', 'TEXT'],
   ['subscribedUntil', 'TEXT'],
@@ -58,6 +58,17 @@ const columns = [
 
 (async () => {
   try {
+    const { rows: colRows } = await pool.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'fans';`
+    );
+    const hasCamel = colRows.some((r) => r.column_name === 'isSubscribed');
+    const hasLower = colRows.some((r) => r.column_name === 'issubscribed');
+    if (hasCamel && !hasLower) {
+      await pool.query(
+        'ALTER TABLE fans RENAME COLUMN "isSubscribed" TO issubscribed;'
+      );
+    }
+
     for (const [name, type] of columns) {
       const sql = `ALTER TABLE fans ADD COLUMN IF NOT EXISTS ${name} ${type};`;
       await pool.query(sql);
@@ -94,7 +105,7 @@ const columns = [
     // - is_subscribed
     // - issubscribed
     // - isSubscribed
-    const subscriptionCols = ['subscribed', 'is_subscribed', 'issubscribed', 'isSubscribed']
+    const subscriptionCols = ['subscribed', 'is_subscribed', 'issubscribed']
       .map((c) => c.toLowerCase())
       .filter((c) => existingCols.includes(c));
 

--- a/routes/fans.js
+++ b/routes/fans.js
@@ -135,6 +135,7 @@ module.exports = function ({
           isHidden,
           isBookmarked,
           isSubscribed,
+          issubscribed,
           subscribedBy,
           subscribedOn,
           subscribedUntil,
@@ -232,8 +233,8 @@ isBlocked=$16,
 isMuted=$17,
 isRestricted=$18,
 isHidden=$19,
-isBookmarked=$20,
-isSubscribed=$21,
+            isBookmarked=$20,
+            issubscribed=$21,
 subscribedBy=$22,
 subscribedOn=$23,
 subscribedUntil=$24,
@@ -277,7 +278,7 @@ WHERE id=$1`,
               parseBoolean(isRestricted),
               parseBoolean(isHidden),
               parseBoolean(isBookmarked),
-              parseBoolean(isSubscribed),
+              parseBoolean(issubscribed ?? isSubscribed),
               subscribedBy,
               subscribedOnTs,
               subscribedUntilTs,
@@ -306,7 +307,7 @@ WHERE id=$1`,
 id, username, name, avatar, header, website, location, gender, birthday, about,
 notes,
 lastSeen, joined, canReceiveChatMessage, canSendChatMessage, isBlocked, isMuted, isRestricted,
-isHidden, isBookmarked, isSubscribed, subscribedBy, subscribedOn, subscribedUntil, renewedAd,
+isHidden, isBookmarked, issubscribed, subscribedBy, subscribedOn, subscribedUntil, renewedAd,
 isFriend, tipsSum, postsCount, photosCount, videosCount, audiosCount, mediaCount,
 subscribersCount, favoritesCount, avatarThumbs, headerSize, headerThumbs, listsStates,
 subscribedByData, subscribedOnData, promoOffers, parker_name, is_custom
@@ -340,7 +341,7 @@ $40,$41,$42,$43
               parseBoolean(isRestricted),
               parseBoolean(isHidden),
               parseBoolean(isBookmarked),
-              parseBoolean(isSubscribed),
+              parseBoolean(issubscribed ?? isSubscribed),
               subscribedBy,
               subscribedOnTs,
               subscribedUntilTs,
@@ -590,7 +591,7 @@ isMuted AS "isMuted",
 isRestricted AS "isRestricted",
 isHidden AS "isHidden",
 isBookmarked AS "isBookmarked",
-isSubscribed AS "isSubscribed",
+issubscribed,
 subscribedBy AS "subscribedBy",
 subscribedOn AS "subscribedOn",
 subscribedUntil AS "subscribedUntil",
@@ -626,7 +627,7 @@ ORDER BY id`);
   router.get('/fans/unfollowed', async (req, res) => {
     try {
       const dbRes = await pool.query(
-        'SELECT id, username FROM fans WHERE isSubscribed = FALSE ORDER BY id',
+        'SELECT id, username FROM fans WHERE issubscribed = FALSE ORDER BY id',
       );
       res.json({ fans: dbRes.rows });
     } catch (err) {
@@ -649,7 +650,7 @@ ORDER BY id`);
       await ofApiRequest(() =>
         ofApi.post(`/${accountId}/users/${fanId}/follow`),
       );
-      await pool.query('UPDATE fans SET isSubscribed = TRUE WHERE id=$1', [
+      await pool.query('UPDATE fans SET issubscribed = TRUE WHERE id=$1', [
         fanId,
       ]);
       res.json({ success: true });
@@ -677,7 +678,7 @@ ORDER BY id`);
     let fans;
     try {
       const dbRes = await pool.query(
-        'SELECT id, username FROM fans WHERE isSubscribed = FALSE ORDER BY id',
+        'SELECT id, username FROM fans WHERE issubscribed = FALSE ORDER BY id',
       );
       fans = dbRes.rows;
     } catch (err) {
@@ -695,7 +696,7 @@ ORDER BY id`);
         await ofApiRequest(() =>
           ofApi.post(`/${accountId}/users/${fan.id}/follow`),
         );
-        await pool.query('UPDATE fans SET isSubscribed = TRUE WHERE id=$1', [
+        await pool.query('UPDATE fans SET issubscribed = TRUE WHERE id=$1', [
           fan.id,
         ]);
         res.write(

--- a/server.js
+++ b/server.js
@@ -305,11 +305,11 @@ let sendMessageToFan = async function (
   let template = [greeting, body].filter(Boolean).join(' ').trim();
   const accountId = await getOFAccountId();
   const dbRes = await pool.query(
-    'SELECT parker_name, username, location, isSubscribed AS "isSubscribed", canReceiveChatMessage AS "canReceiveChatMessage" FROM fans WHERE id=$1',
+    'SELECT parker_name, username, location, issubscribed, canreceivechatmessage FROM fans WHERE id=$1',
     [fanId],
   );
   const row = dbRes.rows[0] || {};
-  if (!row.isSubscribed || !row.canReceiveChatMessage) {
+  if (!row.issubscribed || !row.canreceivechatmessage) {
     const err = new Error(
       'Fan is not subscribed or cannot receive chat messages',
     );
@@ -567,7 +567,7 @@ async function processRecurringPPVs() {
     );
     if (ppvRes.rows.length === 0) return;
     const fansRes = await pool.query(
-      'SELECT id FROM fans WHERE isSubscribed = TRUE AND canReceiveChatMessage = TRUE',
+      'SELECT id FROM fans WHERE issubscribed = TRUE AND canreceivechatmessage = TRUE',
     );
     const fanIds = fansRes.rows.map((r) => r.id);
     for (const ppv of ppvRes.rows) {

--- a/setup-db.js
+++ b/setup-db.js
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS fans (
     isRestricted BOOLEAN,
     isHidden BOOLEAN,
     isBookmarked BOOLEAN,
-    isSubscribed BOOLEAN,
+    issubscribed BOOLEAN,
     subscribedBy TEXT,
     subscribedOn TEXT,
     subscribedUntil TEXT,

--- a/utils/getActiveFans.js
+++ b/utils/getActiveFans.js
@@ -19,11 +19,8 @@ module.exports = async function getActiveFans(pool, { allowAllIfEmpty = true } =
       r.subscribed ??
       r.is_subscribed ??
       (r.issubscribed !== undefined ||
-      r.canreceivechatmessage !== undefined ||
-      r.isSubscribed !== undefined ||
-      r.canReceiveChatMessage !== undefined
-        ? (r.issubscribed ?? r.isSubscribed) &&
-          (r.canreceivechatmessage ?? r.canReceiveChatMessage)
+      r.canreceivechatmessage !== undefined
+        ? r.issubscribed && r.canreceivechatmessage
         : undefined);
     if (activeFlag !== undefined && activeFlag !== null) {
       hasActiveCol = true;


### PR DESCRIPTION
## Summary
- rename camel-cased `isSubscribed` to lowercase `issubscribed`
- adjust migrations and setup scripts to rename legacy column
- update queries, helpers, docs and tests to use `issubscribed`

## Testing
- `node migrate.js`
- `node migrate_add_fan_fields.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e0ad5dd48321b33f423798078bb9