### PR TITLE
Validate vault list id before insert

### DIFF
--- a/routes/vaultLists.js
+++ b/routes/vaultLists.js
@@ -118,7 +118,10 @@ module.exports = function ({
         ofApi.post(`/${accountId}/media/vault/lists`, { name }),
       );
       const list = resp.data?.list || resp.data;
-      const id = list.id;
+      const id = list?.id;
+      if (id == null) {
+        return res.status(400).json({ error: 'id missing in response' });
+      }
       await pool.query(
         'INSERT INTO vault_lists (id, name) VALUES ($1,$2) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name',
         [id, name],


### PR DESCRIPTION
## Summary
- ensure POST /vault-lists verifies OnlyFans response includes a list id
- return 400 without inserting when id is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899eb8d702c83219686914f6dedd62e