### PR TITLE
Use bigint for message IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ If you already have a `messages` table with a `SERIAL` `id`, run the following
 before executing `migrate_messages.js`:
 
 ```sql
-ALTER TABLE messages ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE messages ALTER COLUMN id TYPE BIGINT USING id::BIGINT;
 ALTER TABLE messages ALTER COLUMN id DROP DEFAULT;
 DROP SEQUENCE IF EXISTS messages_id_seq;
 ```
@@ -205,7 +205,7 @@ DROP SEQUENCE IF EXISTS messages_id_seq;
 
 `migrate_messages.js` creates a `messages` table used for storing message history:
 
-- `id` – serial primary key
+- `id` – bigint primary key
 - `fan_id` – reference to `fans.id`
 - `direction` – 'sent' or 'received'
 - `body` – message text

--- a/migrate_messages.js
+++ b/migrate_messages.js
@@ -10,6 +10,7 @@ dotenv.config(); // Load environment variables for db.js
 const pool = require('./db');
 
 // SQL to create or update messages table
+// Use BIGINT for message IDs since OnlyFans message identifiers may exceed 32-bit integers.
 const createTableQuery = `
 CREATE TABLE IF NOT EXISTS messages (
     id BIGINT PRIMARY KEY,
@@ -23,7 +24,8 @@ CREATE TABLE IF NOT EXISTS messages (
 
 // For existing deployments: convert SERIAL integer IDs to BIGINT and drop sequence
 const alterQueries = [
-  'ALTER TABLE messages ALTER COLUMN id TYPE BIGINT',
+  // Explicitly cast existing values to BIGINT and remove auto-increment
+  'ALTER TABLE messages ALTER COLUMN id TYPE BIGINT USING id::BIGINT',
   'ALTER TABLE messages ALTER COLUMN id DROP DEFAULT',
   'DROP SEQUENCE IF EXISTS messages_id_seq',
 ];

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -409,6 +409,7 @@ module.exports = function ({
         [];
       const messages = Array.isArray(raw) ? raw : [];
       for (const m of messages) {
+        // Message IDs can exceed the 32-bit range; convert to string to preserve precision.
         const msgId = m.id != null ? m.id.toString() : null;
         if (msgId == null) continue;
         const direction =


### PR DESCRIPTION
## Summary
- ensure `messages.id` column uses BIGINT
- cast existing IDs to BIGINT during migration
- document bigint IDs and migration steps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4ff4f7208321b7f7f20db4f76cc2